### PR TITLE
Add bank_retrieve to runner functions

### DIFF
--- a/runner_functions.js
+++ b/runner_functions.js
@@ -137,25 +137,30 @@ function bank_withdraw(gold)
 	parent.socket.emit("bank",{operation:"withdraw",amount:gold});
 }
 
-function bank_store(num,pack,pack_slot)
+/**
+ * Store an item in the Bank.
+ *
+ * `bank_store(0)` - Stores the first item in inventory in the first/best spot in bank.
+ * `bank_store(0, "items0", 41)` - Stores the first item in inventory in the last spot in "items0".
+ *
+ * @param {number} inventory_slot Inventory slot number (0-41).
+ * @param {string} [pack] Bank pack (one of "items0"-"items7").
+ * @param {number} [pack_slot=-1] Pack slot number (0-41; default: first available).
+ */
+function bank_store(inventory_slot, pack, pack_slot)
 {
-	// bank_store(0) - Stores the first item in inventory in the first/best spot in bank
-	// parent.socket.emit("bank",{operation:"swap",pack:pack,str:num,inv:num});
-	// Above call can be used manually to pull items, swap items and so on - str is from 0 to 41, it's the storage slot #
-	// parent.socket.emit("bank",{operation:"swap",pack:pack,str:num,inv:-1}); <- this call would pull an item to the first inventory slot available
-	// pack is one of ["items0","items1","items2","items3","items4","items5","items6","items7"]
 	if(!character.bank) return game_log("Not inside the bank");
-	if(!character.items[num]) return game_log("No item in that spot");
-	if(!pack_slot) pack_slot=-1; // the server interprets -1 as first slot available
+	if(!character.items[inventory_slot]) return game_log("No item in that spot");
+	if(!(pack_slot >= 0)) pack_slot=-1; // the server interprets -1 as first slot available
 	if(!pack)
 	{
-		var cp=undefined,cs=undefined;
+		var cp=undefined;
 		for(var cpack in bank_packs)
 		{
 			if(pack || bank_packs[cpack][0]!=character.map || !character.bank[cpack]) continue;
-			for(var i=0;i<42;i++)
+			for(var i=0;i<character.bank[cpack].length;i++)
 			{
-				if(can_stack(character.bank[cpack][i],character.items[num])) // the item we want to store and this bank item can stack - best case scenario
+				if(can_stack(character.bank[cpack][i],character.items[inventory_slot])) // the item we want to store and this bank item can stack - best case scenario
 					pack=cpack;
 				if(!character.bank[cpack][i] && !cp)
 					cp=cpack;
@@ -164,7 +169,28 @@ function bank_store(num,pack,pack_slot)
 		if(!pack && !cp) return game_log("Bank is full!");
 		if(!pack) pack=cp;
 	}
-	parent.socket.emit("bank",{operation:"swap",pack:pack,str:-1,inv:num});
+
+	// This call can be used manually to pull items, swap items and so on - str is from 0 to 41, it's the storage slot #
+	parent.socket.emit("bank",{operation:"swap",pack:pack,str:pack_slot,inv:inventory_slot});
+}
+
+/**
+ * Retrieve an item from the Bank.
+ *
+ * `bank_retrieve("items0", 0)` - Retrieves the first item in the "items0" bank pack.
+ * `bank_retrieve("items0", 0, 41)` - Retrieves the first item in the "items0" bank pack and stores in the last inventory slot.
+ *
+ * @param {string} pack Bank pack (one of "items0"-"items7").
+ * @param {number} pack_slot Bank pack slot number (0-41).
+ * @param {number} [inventory_slot=-1] Inventory slot number (0-41; default: first available).
+ */
+function bank_retrieve(pack, pack_slot, inventory_slot)
+{
+	if(!character.bank) return game_log("Not inside the bank");
+	if(!character.bank[pack] || !character.bank[pack][pack_slot]) return game_log("No item in that spot");
+	if(!(inventory_slot>=0)) inventory_slot=-1; // the server interprets -1 as first slot available
+
+	parent.socket.emit("bank",{operation:"swap",pack:pack,str:pack_slot,inv:inventory_slot});
 }
 
 function swap(a,b) // inventory move/swap


### PR DESCRIPTION
This allows retrieving items that have been stored in the bank.

Additionally fixes two issues in `bank_store`:
- `bank_store` always stores to first slot (ignores `pack_slot`)
- `pack_slot` 0 is interpreted as pick first available