### PR TITLE
Fix hardcoded url for accessing the map editor.

### DIFF
--- a/main.py
+++ b/main.py
@@ -407,7 +407,7 @@ class MapLister(webapp.RequestHandler):
 		def map_to_html(m):
 			return "<div style='margin-bottom: 2px'><a href='%s/%s' target='_blank' style='color: white; font-weight: bold; text-decoration:none'>%s</a></div>"%(url,m.id(),m.id())
 		html="<style> html{background-color:gray}</style>"
-		if is_sdk: url="http://thegame.com/admin/map_editor"
+		if is_sdk: url="%s/admin/map_editor"%(domain.base_url)
 		else: url="%s/%s"%(domain.base_url,"communitymaps")
 		if order=="key":
 			for m in Map.query().fetch(5000,keys_only=True): html+=map_to_html(m)


### PR DESCRIPTION
The map lists links under `<BASEURL>/maps` did not work if
the base_url was set to something else than `thegame.com`. 
The change uses the base_url to craft the link.

Tested with:
`"base_url":"http://adventure-land.local:8083",` in variables.js.
Was able to open the editor again.

