### PR TITLE
Add 'compound_no_scroll' event to 'compound'

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1613,6 +1613,10 @@ function init_socket(args)
 				ui_error("Item combination failed");
 				if(!data.stale) resolve_deferred("compound",{success:false,level:data.level,num:data.num});
 			}
+			else if(response=="compound_no_scroll")
+			{
+				reject_deferred("compound",{reason:"no_scroll"});
+			}
 			else if(response=="compound_in_progress")
 			{
 				ui_log("Another combination in progress","gray");

--- a/node/server.js
+++ b/node/server.js
@@ -5692,6 +5692,9 @@ function init_io() {
 				if (offering && G.items[offering.name].type != "offering") {
 					return socket.emit("game_response", "compound_invalid_offering");
 				}
+				if (!scroll) {
+					return socket.emit("game_response", "compound_no_scroll");
+				}
 				if (!item0 || (item0.level || 0) != data.clevel) {
 					return fail_response("no_item");
 				}


### PR DESCRIPTION
Adds a 'compound_no_scroll' failure event to the 'compound' socket callback, instead of erroring, also adds a handler to the client for this failure event.