### PR TITLE
Make cxjar not stackable.

### DIFF
--- a/design/items.py
+++ b/design/items.py
@@ -4517,7 +4517,6 @@ materials={
 		"name":"CX Jar",
 		"explanation":"An appearance liquified and stored inside a jar.",
 		"exclusive":True,
-		"s":True,
 		"g":1,
 	},
 	"emotionjar":{


### PR DESCRIPTION
CXJars being stackable leave them vulnerable to their data fields being wiped. For example when listing in a merchant stand and selling it, the data field will be removed upon purchase leaving the buyer with an empty jar. This item doesn't really need to be stackable anyways.

I'm not sure if this will fix existing items in the wild, but it'll at least fix future items.