### PR TITLE
Fix `woven` debuff

### DIFF
--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -2712,7 +2712,7 @@ function add_condition(target, condition, args) {
 	}
 	if (condition == "woven") {
 		C.s = min((target.is_monster && 20) || 5, (target.s.woven && target.s.woven.s + 1) || 1);
-		C.speed = -3 * condition.s;
+		C.speed = -3 * C.s;
 	}
 	duration = max((target.s[condition] && target.s[condition].ms) || 0, duration);
 	if (target.stresistance && def && def.debuff) {


### PR DESCRIPTION
This commit fixes a bug where a mob would get NaN speed, instantly putting them at x: NaN, y: NaN, making them unkillable, but they also would not lose aggro on the player unless the player used something like Scare.