### PR TITLE
Add `version` to welcome socket data

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -4162,6 +4162,7 @@ function init_io() {
 			pvp: is_pvp,
 			gameplay: gameplay,
 			info: (instances[socket.first_map] && instances[socket.first_map].info) || {},
+			version: G.version,
 		};
 		socket.first_map = socket.first_in = observer_map;
 		socket.first_x = observer_x;


### PR DESCRIPTION
Knowing what version the server is running will let people know they should grab newer `G` data if their versions don't match.