### PR TITLE
When Fishing or Mining something that uses `open` keep the phrase

### DIFF
--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -3452,7 +3452,15 @@ function exchange(player, name, args) {
 					bundle: drop[1] == "cxbundle",
 				});
 			} else if (drop[1] == "open") {
-				exchange(player, drop[2]);
+				switch (args.phrase) {
+					case "Fished":
+						args.phrase = `Fished ${drop[2]} and got`;
+						break;
+					case "Mined":
+						args.phrase = `Mined ${drop[2]} and got`;
+						break;
+				}
+				exchange(player, drop[2], args);
 			} else {
 				var item = create_new_item(drop[1], drop[2]);
 				var prop = undefined;


### PR DESCRIPTION
When you fish up lglitch instead of saying you got the item by fishing, it would say you just "Received" it. this patch preserves the context for Fishing and Mining in the phrase.

![image](https://github.com/kaansoral/adventureland/assets/9084377/40960fa8-742e-470f-922f-bcb83a0c59ad)


