### PR TITLE
Improve instance enter handling

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1943,6 +1943,11 @@ function init_socket(args)
 				ui_log("Can't reach","gray");
 				transporting=false;
 			}
+			else if(response=="transport_cant_invalid")
+			{
+				ui_log("Instance not found","gray");
+				transporting=false;
+			}
 			else if(response=="transport_cant_item")
 			{
 				ui_log("Item not found","gray");

--- a/node/server.js
+++ b/node/server.js
@@ -5048,8 +5048,15 @@ function init_io() {
 				if (simple_distance(player, { in: f, map: f, x: ref[0], y: ref[1] }) > 120) {
 					return fail_response("transport_cant_reach");
 				}
-				if (data.name && instances[data.name] && instances[data.name].map == data.place) {
-					transport_player_to(player, data.name);
+				if (data.name) {
+					// Player requested to enter an existing instance
+					if (instances[data.name] && instances[data.name].map == data.place) {
+						// The instance exists
+						transport_player_to(player, data.name);
+					} else {
+						// The instance doesn't exist
+						return fail_response("transport_cant_invalid");
+					}
 				} else {
 					if (!consume_one_by_id(player, item)) {
 						return fail_response("transport_cant_item");


### PR DESCRIPTION
Changes:

- Adds an error message for when the player tries to enter a specific instance that doesn't exist
- When a player tries to enter a specific instance that doesn't exist, and the player has a key for that instance in their inventory, it will no longer use a key to open a new instance.