### PR TITLE
Recursive expansion of auto-opened exchangeables

### DIFF
--- a/js/html.js
+++ b/js/html.js
@@ -1819,7 +1819,20 @@ function render_item_help(container,name,level,pure)
 			}
 		}
 	}
+	
 	var items=[];
+
+	function recur_replace(table) {
+		for (let [idx, drop_item] of table.entries()) {
+			if (drop_item[1] === 'open') table.splice(idx, 1, ...G.drops[drop_item[2]])
+		}
+
+		return table
+	}
+	/*
+	[21/01/24] The below isn't sufficient to show that the Crossbow can be obtained from `lostearring1`. `lostearring1`'s droptable only includes an opened `weaponbox`
+	But because `lostearring1` doesn't directly & shallowly show that it drops a Crossbow, Crossbow's only source is `weaponbox`
+	This can lead to confusion. Instead, a recursive expansion of auto-opened drop tables is peformed
 	for(var iname in G.items)
 	{
 		if(!G.items[iname].e) continue;
@@ -1843,6 +1856,32 @@ function render_item_help(container,name,level,pure)
 			}
 		}
 	}
+	New to-render function below
+	*/
+	for (let iname in G.items) {
+		// Early continue if item isn't exchangeable
+		if (!G.items[iname].e) continue
+
+		var levels = [0]
+		var item = G.items[iname]
+		if (item.upgrade || item.compound) levels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+		for (let lvl = 0; lvl < levels.length; lvl++) {
+			var temp_name = `${iname}${lvl ? lvl : ''}`
+
+			// Early continue if drop table doesn't exist
+			if (!G.drops[temp_name]) continue
+
+			var table = G.drops[temp_name]
+			var true_table = recur_replace(table)
+
+			for (let drop_table_item of true_table) {
+				if (drop_table_item[1] === name) items.push([iname, lvl])
+			}
+
+		}
+	}
+
 	var tokens=[];
 	for(var tname in G.tokens)
 	{


### PR DESCRIPTION
This came about because, as a new player, I couldn't find the sources for some items. I had to manually go through each drop table to find, for example, where a elixirs come from. Or, on the other end, wondering why a `lostearring1` shows `crossbow` in it's drop table, but a Crossbow doesn't list `lostearring1` as a source

This PR fixes some weird edge cases where, for example, a Crossbow doesn't have a `lostearring1` as a source.
Also fixes issues where `elixirvit0` and similar elixirs don't show the exchangeable `shell` as a source.

Notably, this does not interfere with the comment from 2022 around this function, which removed showing exchangeables like `lostearring1` from showing as a source for `weaponbox`, since `lostearring1` auto-opens a `weaponbox`.

The solution is a new recursive internal function `recur_replace`. This scans the drop table of all exchangeable items and looks for an entry whose [1] index is 'open'. 'open' in this context means the drop table in the [2] index is _**automatically opened_**. If it finds one of these items, `recur_replace` replaces that drop table entry with the contents of the automatically opened drop table.

Then, in the loop where we find which exchangeable items to show as a source, we simply look through these modified, recursively expanded drop tables.

For example: the Crossbow, `weaponbox`, and `lostearring1`
`lostearring1`s drop table is simply
```
[[
	1,
	'open',
	'weaponbox',
]]
```
So, our function will see this and replace `lostearring1`s drop table with the contents of `weaponbox`. Then, when we iterate through these modified drop tables, we can find that `lostearring1` could indeed drop a crossbow

![Crossbow](https://github.com/kaansoral/adventureland/assets/16968665/959da243-57a0-4f50-a400-e5bd5c96f3b5)
![weaponbox](https://github.com/kaansoral/adventureland/assets/16968665/8f694712-b396-4901-9a11-c7e4f6640dce)
