### PR TITLE
is_same no longer prevents using absorb in sdk mode

### DIFF
--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -471,9 +471,6 @@ function is_map_pvp(map, allow_safe) {
 }
 
 function is_same(player1, player2, party) {
-	if (is_sdk && player1.name != player2.name) {
-		return false;
-	}
 	if (player1.name == player2.name) {
 		return true;
 	}


### PR DESCRIPTION
When trying to use `absorb` as a priest on a friendly party member
the code would not consider us in party when running in SDK mode.

This removes that check