### PR TITLE
Fix small bug with async code snippets

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1663,7 +1663,7 @@ function code_eval(snippet)
 {
 	var f="eval";
 	if(snippet.search("output=")!=-1 || snippet.search("json_output=")!=-1) f="eval_s";
-	if(snippet.search("await")!=-1) snippet="(async () => {"+snippet+"})()";
+	if(snippet.search("await")!=-1) snippet="(async () => {"+snippet+"\n})()";
 	if(code_active)
 	{
 		call_code_function(f,snippet);


### PR DESCRIPTION
If a code snippet used await, and had a line comment on the last line, it would fail to run:
```js
await sleep(1000);
show_json(100);
// show_json(200);
```
This is because the line comment would end up cutting off the end of the async function wrapper that `code_eval` creates.