### PR TITLE
Fix infinite range for `curse`, `cburst`, and `3shot`/`5shot`

### DIFF
--- a/design/skills.py
+++ b/design/skills.py
@@ -232,6 +232,8 @@ skills={
 		"cooldown":60000,
 		"target":True,
 		"hostile":True,
+		"use_range":True,
+		"range_multiplier":2,
 	},
 	"rspeed":{
 		"type":"skill",

--- a/design/skills.py
+++ b/design/skills.py
@@ -810,6 +810,7 @@ skills={
 		"name":"Curse",
 		"explanation":"Cursed opponents receive 20% more damage, deal 20% less damage and they slow down by 20.",
 		"mp":400,
+		"range":200,
 		"duration":5000,
 		"cooldown":5000,
 		"condition":"cursed",

--- a/design/skills.py
+++ b/design/skills.py
@@ -221,6 +221,7 @@ skills={
 		"cooldown":60000,
 		"target":"monster",
 		"hostile":True,
+		"use_range":True,
 	},
 	"tangle":{
 		"type":"skill",

--- a/design/skills.py
+++ b/design/skills.py
@@ -644,6 +644,7 @@ skills={
 		"warning":"Highly unbalanced skill, could get nerfed or modified",
 		"hostile":True,
 		"projectile":"mentalburst",
+		"use_range":True,
 	},
 	"quickpunch":{
 		"type":"skill",
@@ -748,6 +749,7 @@ skills={
 		"pierces_immunity":True,
 		"damage_type":"physical",
 		"procs":True,
+		"use_range":True,
 	},
 	"3shot":{
 		"type":"skill",

--- a/design/skills.py
+++ b/design/skills.py
@@ -606,6 +606,9 @@ skills={
 		"cooldown":10000,
 		"target":True,
 		"hostile":True,
+		"range_multiplier":3,
+		"range_bonus":20,
+		"use_range": True
 	},
 	"pcoat":{
 		"type":"skill",

--- a/node/server.js
+++ b/node/server.js
@@ -8594,10 +8594,13 @@ function init_io() {
 					// Only look at the first 16 targets in the array if more are provided
 					for (const t of data.targets.slice(0, 16)) {
 						const id = t[0];
+
+						// Prevent attacking the same entity twice
 						if (targeted[id]) {
 							continue;
 						}
 						targeted[id] = true;
+
 						const mp = max(0, parseInt(t[1]) || 0);
 						if (mp <= 0) {
 							continue;
@@ -8678,15 +8681,17 @@ function init_io() {
 				if (is_array(data.ids)) {
 					// Only look at the first Xshot targets in the array if more are provided
 					for (const id of data.ids.slice(0, data.name === "5shot" ? 5 : 3)) {
+						// Prevent attacking the same entity twice
 						if (targeted[id]) {
-							// Already targeted this monster
 							continue;
 						}
 						targeted[id] = true;
+
 						target = instances[player.in].monsters[id];
 						if (!target) {
 							target = instances[player.in].players[id];
 						}
+
 						if (!target || is_invinc(target) || target.name == player.name) {
 							continue;
 						}

--- a/node/server.js
+++ b/node/server.js
@@ -8703,7 +8703,6 @@ function init_io() {
 							continue;
 						}
 						if (!c_resolve) {
-							consume_mp(player, gSkill.mp, target);
 							c_resolve = attack;
 							attack.pids = [attack.pid];
 							attack.targets = [attack.target];
@@ -8715,6 +8714,7 @@ function init_io() {
 				}
 				player.halt = false;
 				player.to_resend = "u+cid";
+				consume_mp(player, gSkill.mp, target);
 				if (!c_resolve) {
 					reject = { failed: true, place: data.name, reason: "no_target" };
 					disappearing_text(player.socket, player, "NO HITS");

--- a/node/server.js
+++ b/node/server.js
@@ -8266,6 +8266,7 @@ function init_io() {
 
 			// Range check
 			const isTargetTooFar = (target) => {
+				// Use the range of the skill, falling back to the player range if it isn't set
 				let range = gSkill.range || player.range;
 				if (gSkill.range_multiplier) {
 					range *= gSkill.range_multiplier;
@@ -8288,11 +8289,8 @@ function init_io() {
 				}
 				return false;
 			};
-			if (target && (gSkill.range || gSkill.use_range)) {
-				if (isTargetTooFar(target)) {
-					fail_response("too_far", data.name, { dist: dist, id: target.id });
-					return;
-				}
+			if (target && isTargetTooFar(target)) {
+				return fail_response("too_far", data.name, { dist: dist, id: target.id });
 			}
 
 			// Consume item check


### PR DESCRIPTION
Changes:
- Add range checks for skills that use lists of targets (`cburst`, `3shot`, `5shot`)
- Add `use_range` to skills that had `target` set, but not `range`
- Fall back to using character range if neither `use_range` nor `range` is set
- Set `curse` to 200 range (before refactoring it was `min(200, attacker.range * 5 + 20)`)
- Set `huntersmark` range to the same as supershot (`3X + 20`) (was vision range before refactoring)
- Set `tangle` to `2X` range (was vision range before refactoring)