### PR TITLE
Change equip_batch's base cost from 1 to 0.5

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -4093,7 +4093,7 @@ function init_io() {
 						climit = round(climit / 4);
 					}
 					if (method == "equip_batch") {
-						var cost = 1;
+						var cost = 0.5;
 						if (Array.isArray(data)) {
 							cost += data.length / 2;
 						}


### PR DESCRIPTION
This makes it clear to the user that they should use equip_batch for 2 items. Previously, if the user used it on 2 items, they would receive the same CC either way. This change removes ambiguity.