### PR TITLE
hotfix for magiport

### DIFF
--- a/design/skills.py
+++ b/design/skills.py
@@ -456,6 +456,7 @@ skills={
 		"cooldown":0,
 		"target":"player",
 		"global":True,
+		"range": 8000
 	},
 	"charge":{
 		"type":"skill",


### PR DESCRIPTION
give magiport a large range, we should handle .global skills and ignore the range check if they are global