### PR TITLE
Implement Fire Resistance Changes

### DIFF
--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -2698,19 +2698,23 @@ function add_condition(target, condition, args) {
 		disappearing_text(target.socket, target, "FREEZE!", { xy: 1, size: "huge", color: "freeze", nv: 1 });
 	}
 	if (condition == "burned") {
+		let scale = 1.0 - (target.firesistance || 0) / 100.0;
 		duration = 5000;
 		if (!args.attack) {
 			args.attack = 1000;
 		}
 		if (args.divider == 3 && target.s.burned && target.s.burned.ms) {
-			duration = min(
-				12000,
-				max(duration + 400, min(8000, parseInt(duration / 4 + (50 * args.attack) / (target.s.burned.intensity + 200)))),
+			duration = parseInt(
+				scale *
+					min(
+						12000,
+						max(duration + 400, min(8000, duration / 4 + (50 * args.attack) / (target.s.burned.intensity + 200))),
+					),
 			);
 		}
 		C.intensity = max(
 			(target.s.burned && target.s.burned.intensity) || 1,
-			parseInt(((target.s.burned && target.s.burned.intensity) || 0) / (args.divider || 3) + args.attack),
+			parseInt((scale * ((target.s.burned && target.s.burned.intensity) || 0)) / (args.divider || 3) + args.attack),
 		);
 		C.fid = args.fid;
 		disappearing_text({}, target, "BURN!", { xy: 1, size: "huge", color: "burn", nv: 1 }); //target.is_player&&"huge"||undefined


### PR DESCRIPTION
(Original PR: #105)

This PR changes Fire Resistance to not only affect the chance of getting burned, but also having higher Fire Resistance reduces the duration and intensity of the burn debuff. For instance, if the player had N fire resistance, they would have a N% chance to simply not get burned, but also, the duration would be reduced by N%, and the intensity would be reduced by N%.