### PR TITLE
Fix bug regarding shiny items

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -12389,12 +12389,10 @@ function update_instance(instance) {
 					}
 
 					if (success && !player.p.u_fail) {
-						if (announce) {
-							player.hitchhikers.push([
-								"game_response",
-								{ response: "upgrade_success", level: new_level, num: ref.num, stale: ref.stale },
-							]);
-						}
+						player.hitchhikers.push([
+							"game_response",
+							{ response: "upgrade_success", level: new_level, num: ref.num, stale: ref.stale },
+						]);
 						if (announce && calculate_item_value(item) > 4800000 && !player.stealth) {
 							broadcast("server_message", {
 								message: player.name + " received " + item_to_phrase(item),


### PR DESCRIPTION
This PR aims to fix a bug where if a user attempts to shiny an item using the upgrade station and an offering, if it succeeds, the server does not send a response. This appears to occur because the server sets a "announce" flag to be false when the upgrade is a shiny attempt, and this prevents the success response from being sent to the client.