### PR TITLE
Destat NPC

### DIFF
--- a/design/maps.py
+++ b/design/maps.py
@@ -1221,6 +1221,7 @@ maps={
 		"npcs":[
 			{"id":"transporter","position":[-14,-477]},
 			{"id":"locksmith","position":[316,-270]},
+			{"id":"scrollsmith","position":[606,-1590]},
 		],
 		"monsters":[
 			{"type":"plantoid","boundary":[-1013,-472,-575,-130],"count":4,"grow":True}, #added grow 31/1/2024

--- a/design/npcs.py
+++ b/design/npcs.py
@@ -891,6 +891,13 @@ npcs={
 		"type":"fullstatic",
 		"name":"Smith",
 	},
+	"scrollsmith":{
+		"role":"scrollsmith",
+		"skin":"bsoldier",
+		"says":"X",
+		"type":"fullstatic",
+		"name":"Sir Bob",
+	},
 	"transporter":{
 		"role":"transport",
 		"skin":"spell",

--- a/design/sprites.py
+++ b/design/sprites.py
@@ -372,7 +372,7 @@ sprites={
 		"columns":4,
 		"matrix":[
 			[None,"nexus",None,None],
-			[None,None,None,None],
+			[None,None,"bsoldier",None],
 		]
 	},
 	"military3":{

--- a/js/functions.js
+++ b/js/functions.js
@@ -2953,6 +2953,14 @@ function lock_item(num)
 	return push_deferred("locksmith");
 }
 
+function destat_item(num)
+{
+	if(num===undefined) num=s_item;
+	socket.emit("destat",{num:num});
+	return push_deferred("destat");
+}
+
+
 function seal_item(num)
 {
 	if(num===undefined) num=l_item;
@@ -3204,6 +3212,7 @@ function reopen()
 		else if(rendered_target=="dismantler") render_dismantler();
 		else if(rendered_target=="none") render_none_shrine();
 		else if(rendered_target=="locksmith") render_locksmith();
+		else if(rendered_target=="scrollsmith") render_scrollsmith();
 		// else if(rendered_target=="secondhands") render_secondhands(); // Manual resets
 		if(inventory) reset_inventory();
 
@@ -3270,7 +3279,7 @@ function reset_inventory(condition)
 {
 	if(inventory)
 	{
-		if(condition && !in_arr(rendered_target,["upgrade","compound","exchange","npc","merchant","craftsman","dismantler","none","locksmith"])) return;
+		if(condition && !in_arr(rendered_target,["upgrade","compound","exchange","npc","merchant","craftsman","dismantler","none","locksmith","scrollsmith"])) return;
 		render_inventory(true);
 	}
 }

--- a/js/game.js
+++ b/js/game.js
@@ -2194,6 +2194,15 @@ function init_socket(args)
 			}
 			else if(response=="magiport_failed") ui_log("Magiport failed","gray"),no_no_no(2);
 			else if(response=="revive_failed") ui_log("Revival failed","gray"),no_no_no(1);
+			else if(response=="scrollsmith_cant")
+			{
+				ui_log("Can't destat this item","gray")
+			}
+			else if(response=="scrollsmith_success")
+			{
+				ui_log("Spent " + data.gold.toLocaleString() + " gold","gray");
+				ui_log("De-statted the item","gray");
+			}
 			else if(response=="locksmith_cant")
 			{
 				ui_log("Can't lock/unlock this item","gray")
@@ -3256,6 +3265,10 @@ function npc_right_click(event){
 	if(this.role=="locksmith")
 	{
 		render_interaction({auto:true,dialog:"locksmith",skin:"asoldier"});
+	}
+	if(this.role=="scrollsmith")
+	{
+		render_interaction({auto:true,dialog:"scrollsmith",skin:"bsoldier"});
 	}
 	if(this.role=="compound")
 	{

--- a/js/html.js
+++ b/js/html.js
@@ -1,4 +1,4 @@
-var u_item=null,u_scroll=null,u_offering=null,c_items=e_array(3),c_scroll=null,c_offering=null,c_last=0,e_item=null,p_item=null,l_item=null,cr_items=e_array(9),cr_last=0,ds_item=null;
+var u_item=null,u_scroll=null,u_offering=null,c_items=e_array(3),c_scroll=null,c_offering=null,c_last=0,e_item=null,p_item=null,l_item=null,s_item=null,cr_items=e_array(9),cr_last=0,ds_item=null;
 
 var settings_shown=0;
 function show_settings()
@@ -1131,6 +1131,30 @@ function render_locksmith(mode)
 					//html+="<div class='ering ering4'>";*/
 					html+="<div>";
 						html+=item_container({shade:shade,cid:'litem',s_op:0.4,draggable:false,droppable:true});
+					html+="</div>";
+					//html+="</div>";
+				/*html+="</div>";
+			html+="</div>";
+		html+="</div>";*/
+		html+="<div style='margin-top: 12px'><div class='gamebutton clickable' onclick='"+f+"()'>"+button+"</div></div>";
+	html+="</div>";
+	$("#topleftcornerui").html(html);
+	if(!inventory) render_inventory(),inventory_opened_for=topleft_npc;
+}
+
+function render_scrollsmith()
+{
+	var button="DE-STAT",f="destat_item",shade="shade_chest";
+	reset_inventory(1);
+	topleft_npc="scrollsmith"; rendered_target=topleft_npc;
+	s_item=null;
+	var html="<div style='background-color: black; border: 5px solid gray; padding: 20px; font-size: 24px; display: inline-block; vertical-align: top; text-align: center'>";
+		/*html+="<div class='ering ering1 mb10'>";
+			html+="<div class='ering ering2'>";
+				html+="<div class='ering ering3'>";
+					//html+="<div class='ering ering4'>";*/
+					html+="<div>";
+						html+=item_container({shade:shade,cid:'sitem',s_op:0.4,draggable:false,droppable:true});
 					html+="</div>";
 					//html+="</div>";
 				/*html+="</div>";
@@ -3741,6 +3765,17 @@ function on_rclick(current)
 			$("#citem"+inum).parent().html("");
 			$("#litem").html(html);
 		}
+		else if(topleft_npc=="scrollsmith")
+		{
+			var current=character.items[inum],def=null;
+			if(current) def=G.items[current.name];
+			if(!def) return;
+			if(s_item!==null) return;
+			s_item=inum; cache_i[inum]=-1;
+			var html=$("#citem"+inum).all_html();
+			$("#citem"+inum).parent().html("");
+			$("#sitem").html(html);
+		}
 		else if(topleft_npc=="upgrade")
 		{
 			var current=character.items[inum],def=null;
@@ -4633,6 +4668,11 @@ function render_interaction(type,sub_type,args)
 	{
 		html+="Lock - Prevents anything that can destroy an item, selling, upgrading, you name it! Seal - Locks the item in a way that unlocking it takes two days. Unlock - Frees it. Got it? Good. Cost? 250 big ones.";
 		html+="<span style='float: right; margin-top: 5px'><div class='slimbutton' onclick='render_locksmith(\"lock\")'>LOCK</div> <div class='slimbutton' onclick='render_locksmith(\"seal\")'>SEAL</div> <div class='slimbutton' onclick='render_locksmith(\"unlock\")'>UNLOCK</div></span>";
+	}
+	else if(type=="scrollsmith")
+	{
+		html+="De-stat an item. Give you back the scrolls used on the item, as though the item were level 0. Returns the item back to you along with scrolls. Got it? Good. Cost? Depends on the scroll. 10 times the value of the scrolls that will be returned to you.";
+		html+="<span style='float: right; margin-top: 5px'><div class='slimbutton' onclick='render_scrollsmith()'>DE-STAT</div></span>";
 	}
 	else if(type=="crafting")
 	{

--- a/node/server.js
+++ b/node/server.js
@@ -5612,9 +5612,6 @@ function init_io() {
 			if (!scrolldef) {
 				return fail_response("scrollsmith_cant"); // Just in case there isn't actually an item associated with the scroll... should never happen, though.
 			}
-			if (player.gold < 250000) {
-				return fail_response("gold_not_enough");
-			}
 			var needed = [1, 10, 100, 1000, 9999, 9999, 9999];
 			var ograde = calculate_item_grade(def, { name: item.name, level: 0 });
 			var cost = needed[ograde] * scrolldef.g * 10;

--- a/node/server.js
+++ b/node/server.js
@@ -5588,8 +5588,6 @@ function init_io() {
 
 		socket.on("destat", function (data) {
 			var player = players[socket.id];
-			var item = player.items[data.item_num];
-			var def = G.items[item && item.name];
 			if (!player || player.user) {
 				return fail_response("cant_in_bank");
 			}

--- a/node/server.js
+++ b/node/server.js
@@ -5621,11 +5621,7 @@ function init_io() {
 			if (player.gold < cost) {
 				return fail_response("gold_not_enough");
 			}
-			if (
-				!can_add_items(player, list_to_pseudo_items([[neeeded[ograde], scrolltype]]), {
-					space: 1,
-				})
-			) {
+			if (!can_add_items(player, list_to_pseudo_items([[needed[ograde], scrolltype]]))) {
 				return fail_response("inv_size");
 			}
 			player.gold -= cost;


### PR DESCRIPTION
This pull request adds an NPC to Desertland that allows players to remove the stat modifier from an item that has had one applied via scrolls. This process only works on items that have a stat applied to them, i.e. `item.stat_type != null`.

The number of scrolls returned is equivalent to the number of scrolls that would be required to apply the stat to the item if it were at level 0. For example, if Wanderer's Breeches (common at +0) were upgraded to level 7 (they are High grade at +7), and then Intelligence scrolls were used to apply Intelligence to the item (10 scrolls would be required), and then the item were brought to this NPC, the NPC would return only 1 Intelligence scroll.

Additionally, the cost scales with the number of scrolls that would be returned - it is 10 times the value of `G.items[scrollname].g` times the quantity of scrolls returned. For our example with Wanderer's Breeches +7, it would cost 8,000 gold (at the time of writing, prices may change for rarer scrolls).

As a precaution, the NPC cannot return scrolls for which there exist no scroll definition: Suppose that an item somehow had "charisma", then the NPC would not return an invalid "charismascroll" item.

The NPC can be found in Desertland, near the purple Scorpion spawn.
