### PR TITLE
add timeout to `use`

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -9750,7 +9750,6 @@ function init_io() {
 				if (player.last.potion) {
 					const ms = -mssince(player.last.potion);
 					if (ms > 0) {
-						socket.emit("eval", { code: `pot_timeout(${ms})` });
 						return fail_response("not_ready", { ms: ms });
 					}
 				}

--- a/node/server.js
+++ b/node/server.js
@@ -9756,11 +9756,11 @@ function init_io() {
 				}
 				player.last.potion = future_ms(4000);
 				if (data.item == "hp") {
-					player.hp = min(player.hp + 50, player.max_hp);
+					player.hp = Math.min(player.hp + 50, player.max_hp);
 					disappearing_text(socket, player, "+50", { color: "green", xy: 1, s: "hp", nohp: 1 });
 				}
 				if (data.item == "mp") {
-					player.mp = min(player.mp + 100, player.max_mp);
+					player.mp = Math.min(player.mp + 100, player.max_mp);
 					disappearing_text(socket, player, "+100", { color: "#006AA9", xy: 1, s: "mp", nomp: 1 });
 				}
 				// calculate_player_stats(player); [22/11/16]


### PR DESCRIPTION
Changes:
- Add additional `pot_timeout` eval when `use hp/mp` is on cooldown
- Return `ms` with the remaining cooldown time in `game_response` for `use hp/mp`