### PR TITLE
Showing a skill tooltip now also shows weapon type requirement

### DIFF
--- a/js/html.js
+++ b/js/html.js
@@ -2201,6 +2201,7 @@ function render_skill(selector,skill_name,args)
 			if(skill.range_multiplier && skill.range_bonus) html+=bold_prop_line("Range",to_pretty_float(skill.range_multiplier||1)+"X + "+skill.range_bonus,"gray");
 			else if(skill.range_multiplier) html+=bold_prop_line("Range",to_pretty_float(skill.range_multiplier||1)+"X of Character Range","gray");
 			if(skill.level) html+=bold_prop_line("Level Requirement",skill.level,"gray");
+			if(skill.wtype) html+=bold_prop_line("Weapon Requirement", is_array(skill.wtype) ? skill.wtype.join(", ") : skill.wtype,"gray");
 			if(skill.max) html+=bold_prop_line("Max",skill.max,"gray");
 			if(skill.type=="passive") html+="<div><span style='color: #696C68;'>Passive</span></div>";
 			if(skill.damage_type)


### PR DESCRIPTION
Without digging into G.skills it might not be obvious that `G.skills.cleave` requires an `axe` or a `scythe`, or that `G.skills.stomp` requires a `basher`. This PR helps the player to identify the requirement via the SKILLS menu or the skills located in [docs](https://adventure.land/docs/docs/guide/all/skills_and_conditions) 

![image](https://github.com/kaansoral/adventureland/assets/9084377/0fd693b9-185d-4442-9303-c6622a1f7e52)
![image](https://github.com/kaansoral/adventureland/assets/9084377/89969af1-aa5b-401f-a3e1-cfd852ec970a)
