### PR TITLE
Fix Piercing Shot to actually grant Armor Piercing

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -2972,7 +2972,7 @@ function commence_attack(attacker, target, atype) {
 	}
 	["apiercing", "rpiercing", "miss"].forEach(function (p) {
 		if (attacker[p]) {
-			info[p] = attacker[p];
+			info[p] = (info[p] || 0) + attacker[p];
 		}
 	});
 	if (


### PR DESCRIPTION
Prior to this change, Piercing Shot (A ranger skill) that gives 500 armor piercing would only grant this pierce if the player had no pierce themselves. If the player had pierce, the pierce from the skill would then be overwritten by the player's pierce. This change fixes it by adding the player's pierce (or miss chance!) to the skills stats.