### PR TITLE
Fix bug with Giveaways

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -13202,7 +13202,7 @@ setInterval(function () {
 										to: winner.name,
 										subject: "You've won a giveaway!",
 										message:
-											"Congratulations, you won " + player.name + "'s giveaway. Participants were: " + list.join(", "),
+											"Congratulations, you won " + player.name + "'s giveaway. Participants were: " + list.map(e=>e.name).join(", "),
 										rid: randomStr(50),
 										retries: 5,
 										item: mitem,

--- a/node/server.js
+++ b/node/server.js
@@ -13168,12 +13168,12 @@ setInterval(function () {
 					player.slots[slot].giveaway--;
 					if (!player.slots[slot].giveaway) {
 						var list = [];
-						player.slots[slot].list.forEach(function (p) {
-							var p = get_player(p);
-							if (p && p.esize) {
-								list.push(p);
+						player.slots[slot].list.forEach(function (name) {
+							var player = get_player(name);
+							if (player && player.esize) {
+								list.push(player);
 							} else if (!mode.prevent_external) {
-								list.push({ name: p });
+								list.push({ name });
 							}
 						});
 						if (!list.length) {

--- a/node/server.js
+++ b/node/server.js
@@ -13207,7 +13207,6 @@ setInterval(function () {
 											"'s giveaway. Participants were: " +
 											list.map((e) => e.name).join(", "),
 										rid: randomStr(50),
-										rid: randomStr(50),
 										retries: 5,
 										item: mitem,
 									},

--- a/node/server.js
+++ b/node/server.js
@@ -13202,7 +13202,11 @@ setInterval(function () {
 										to: winner.name,
 										subject: "You've won a giveaway!",
 										message:
-											"Congratulations, you won " + player.name + "'s giveaway. Participants were: " + list.map(e=>e.name).join(", "),
+											"Congratulations, you won " +
+											player.name +
+											"'s giveaway. Participants were: " +
+											list.map((e) => e.name).join(", "),
+										rid: randomStr(50),
 										rid: randomStr(50),
 										retries: 5,
 										item: mitem,


### PR DESCRIPTION
This fixes a bug with giveaways. Giveaways would previously list all of the participants of a giveaway in the mail, but at some point a breaking change occurred, and instead it lists [object Object] multiple times.

Example of bugged behavior:
![image](https://github.com/kaansoral/adventureland/assets/24441367/53c7b68c-ba6f-4932-9c3a-d676e870c0ad)
