### PR TITLE
Move xscorpion spawn so it is inside bounds

### DIFF
--- a/design/maps.py
+++ b/design/maps.py
@@ -1288,7 +1288,7 @@ maps={
 			{"type":"greenjr","boundary":[-720,-820,-418,-203],"count":1},
 
 			{"type":"minimush","boundary":[-166,453,182,808],"count":8,"grow":True},
-			{"type":"mrpumpkin","boundary":[-671,571,-300,800],"count":1,"special":True},
+			{"type":"mrpumpkin","boundary":[-671,571,-320,800],"count":1,"special":True},
 			{"type":"xscorpion","boundary":[-671,571,-320,800],"count":6,"grow":True},
 
 			{"type":"snake","boundary":[141,-792,552,-702],"count":6,"grow":True},

--- a/design/maps.py
+++ b/design/maps.py
@@ -1289,7 +1289,7 @@ maps={
 
 			{"type":"minimush","boundary":[-166,453,182,808],"count":8,"grow":True},
 			{"type":"mrpumpkin","boundary":[-671,571,-300,800],"count":1,"special":True},
-			{"type":"xscorpion","boundary":[-671,571,-300,800],"count":6,"grow":True},
+			{"type":"xscorpion","boundary":[-671,571,-320,800],"count":6,"grow":True},
 
 			{"type":"snake","boundary":[141,-792,552,-702],"count":6,"grow":True},
 			{"type":"osnake","boundary":[141,-792,552,-702],"count":2},


### PR DESCRIPTION
This PR makes a single change to the XScorpion spawn in the Halloween map, moving its spawn box so that it is always inside the bounds.

Before:
![image](https://github.com/kaansoral/adventureland/assets/24441367/efdd2384-094e-4a33-98e8-90f5b2c77951)
After:
![image](https://github.com/kaansoral/adventureland/assets/24441367/16ae8bc9-c7f2-4f0a-9c55-daeb68895c05)
