### PR TITLE
Align firebow with other fire weapons

### DIFF
--- a/design/drops.py
+++ b/design/drops.py
@@ -274,7 +274,7 @@ drops={
 		"mvampire":[[0.10,"intearring"],[0.10,"strearring"],[0.10,"dexearring"],[0.05,"firestaff"],[0.03,"mcape"],[0.01,"forscroll"],[1.0/400000,"cxjar",1,"coolblueg"],[1.0/80000,"sanguine"]],
 		"fvampire":[[0.30,"open","statamulet"],[0.04,"firestaff"],[0.01,"mcape"],[0.01,"armorbox"],[0.01,"forscroll"],[1.0/200000,"cxjar",1,"catbatg"],[1.0/40,"offeringp"],[1.0/50000,"sanguine"]],
 		#"phoenix":[[0.08,"intearring"],[0.08,"strearring"],[0.08,"dexearring"],[0.02,"firestaff"],[0.02,"fireblade"]],
-		"phoenix":[[0.7,"vitscroll"],[0.12,"intearring"],[0.12,"strearring"],[0.12,"dexearring"],[0.12,"vitearring"],[0.04,"firestaff"],[0.04,"fireblade"],[1.0/120000,"fcape"],[1.0/600,"offeringp"],[1.0/64000000,"cxjar",1,"hairdo606"]],
+		"phoenix":[[0.7,"vitscroll"],[0.12,"intearring"],[0.12,"strearring"],[0.12,"dexearring"],[0.12,"vitearring"],[0.04,"firestaff"],[0.04,"firebow"],[0.04,"fireblade"],[1.0/120000,"fcape"],[1.0/600,"offeringp"],[1.0/64000000,"cxjar",1,"hairdo606"]], # Added firebow [2024/04/12]
 		"mechagnome":[[0.2,"electronics"],[0.2,"electronics"],[0.2,"electronics"],[0.00001,"networkcard"],[1.0/10000000,"mpxamulet"]],
 		"bat":[[4.0/1000,"wbook0"],[5.0/1000,"bwing"],[1.0/100000000,"cxjar",1,"wings102"]],
 		"scorpion":[
@@ -1067,6 +1067,7 @@ drops={
 		[0.5,"pmace"],
 		[1,"fireblade"],
 		[0.8,"firestaff"],
+		[0.8,"firebow"], # Added firebow [2024/04/12]
 		[0.04,"t3bow"],
 		[0.02,"hammer"],
 		[0.1,"rapier"],

--- a/design/items.py
+++ b/design/items.py
@@ -2923,7 +2923,7 @@ weapons={
 		"name":"Fire Bow",
 		"explanation":"Rains fire upon the enemy",
 		"g":178000,
-		"grades":[0,7],
+		"grades":[0,8],
 		"a":True,
 		"cx":{"accent":"#E34C25"},
 		#"cx":{"accent":"#D3001E"},

--- a/design/recipes.py
+++ b/design/recipes.py
@@ -140,9 +140,9 @@ craft={
 	"firebow":{
 		"items":[
 			[1,"bow"],
-			[2,"essenceoffire"],
+			[1,"essenceoffire"], # Was 2 [2024/04/12]
 		],
-		"cost":40000,
+		"cost":20000, # Was 40000 [2024/04/12]
 	},
 	"fireblade":{
 		"items":[
@@ -545,6 +545,12 @@ dismantle={
 		"cost":40,
 	},
 	"fireblade":{
+		"items":[
+			[1,"essenceoffire"],
+		],
+		"cost":10000,
+	},
+	"firebow":{  # Added firebow [2024/04/12]
 		"items":[
 			[1,"essenceoffire"],
 		],


### PR DESCRIPTION
This PR attempts to make the `firebow` align with other fire weapons. (`fireblade` and `firestaff`, specifically).  
This change is made so the ranger class will have easier access to interesting and more varied weapons.  
In its current state, the `firebow` was almost never used. While not making it god tier, this PR tries to make it more accessible.

Note: Adding the `firebow` to the `weaponbox` has the side effect of diluting the loot pool (See image below). I've made a Discord poll [here](https://discord.com/channels/238332476743745536/1228326390294646834/1228331775886098514) to make sure nobody is strongly opposed to that change.

### Detailed changes:
- Now possible to dismantle firebow
- Firebow essenceoffire cost reduced to 1 (was 2)
- Firebow crafting cost reduced to 20k (was 40k)
- Firebow can be looted from the phoenix
- Firebow can be obtained from weaponbox
- Firebow grade went from `0,7` to `0,8` like the `fireblade`

Discord suggestion thread: https://discord.com/channels/238332476743745536/1228326390294646834/1228326390294646834

`weaponbox` drop pool changes:
![image](https://github.com/kaansoral/adventureland/assets/6382729/75f4bc08-c045-4183-9b03-97d9c94d360e)