### PR TITLE
maps.py configurable enter requirements

### DIFF
--- a/design/maps.py
+++ b/design/maps.py
@@ -145,7 +145,10 @@ maps={
 		"enter": {
 			# requirements to enter the dungeon
 			# TODO level, class, 
-			"items": [["cryptkey", 1]], #requires 1 cryptkey to enter
+   			#requires 1 cryptkey to enter
+   			"items": {
+				"cryptkey": 1
+			},
 			
 			# [mapKey, locationType, locationIndex, range]
 			"locations": [
@@ -1165,7 +1168,10 @@ maps={
 		"enter": {
 			# requirements to enter the dungeon
 			# TODO level, class, 
-			"items": [["frozenkey", 1]], #requires 1 frozenkey to enter
+   			"items": {
+          		#requires 1 frozenkey to enter
+				"frozenkey": 1
+			},
 			
 			# [mapKey, locationType, locationIndex, range]
 			"locations": [

--- a/design/maps.py
+++ b/design/maps.py
@@ -142,6 +142,17 @@ maps={
 			[-1.54,105.6,126.56,56.96,"cave",2,0],
 		],
 		"instance":True,
+		"enter": {
+			# requirements to enter the dungeon
+			# TODO level, class, 
+			"items": [["cryptkey", 1]], #requires 1 cryptkey to enter
+			
+			# [mapKey, locationType, locationIndex, range]
+			"locations": [
+				# ["cave", "spawns", 2, 120], # spawn in front of door 
+				["cave", "doors", 2, 120] # door at crypt castle
+			]
+		}
 	},
 	"goobrawl":{
 		"key":"jayson_GooIsland",

--- a/design/maps.py
+++ b/design/maps.py
@@ -1162,6 +1162,17 @@ maps={
 		"drop_norm":4000,
 		"instance":True,
 		"lux":0.75,
+		"enter": {
+			# requirements to enter the dungeon
+			# TODO level, class, 
+			"items": [["frozenkey", 1]], #requires 1 frozenkey to enter
+			
+			# [mapKey, locationType, locationIndex, range]
+			"locations": [
+				# ["winterland", "spawns", 5, 120],
+				["winterland", "doors", 3, 120] 
+			]
+		}
 	},
 	"winterland":{
 		#"key":"jayson_IceLandPrototype",

--- a/node/server.js
+++ b/node/server.js
@@ -5239,8 +5239,7 @@ function init_io() {
 							// validate missing quantities
 							if (Object.keys(quantityByItem).length > 0) {
 								server_log(`${data.place} missing items ${JSON.stringify(quantityByItem)}`);
-								// TODO: tell missing requirements to the client?
-								return fail_response("transport_cant_item");
+								return fail_response("transport_cant_item", data.place, { items: quantityByItem });
 							}
 
 							for (const [inventory_index, quantity] of itemsToConsume) {

--- a/node/server.js
+++ b/node/server.js
@@ -5181,7 +5181,7 @@ function init_io() {
 								}
 
 								const location = G.maps[locationsMapKey][locationType][locationIndex];
-								const distanceToLocation = simple_distance(player, {
+								const distanceToLocation = distance(player, {
 									in: locationsMapKey,
 									map: locationsMapKey,
 									x: location[0],

--- a/node/server.js
+++ b/node/server.js
@@ -5150,10 +5150,13 @@ function init_io() {
 
 					const instanceExists = data.name && instances[data.name] && instances[data.name].map == data.place;
 
-					// Player requested to enter an existing instance
-					if (!instanceExists) {
-						// The instance doesn't exist
-						return fail_response("transport_cant_invalid");
+					if (data.name) {
+						// Player requested to enter an existing instance
+						if (!instanceExists) {
+							// The instance doesn't exist
+							server_log(`${player.name} tried to enter ${data.place} (${data.name}) but it does not exist`);
+							return fail_response("transport_cant_invalid");
+						}
 					}
 
 					// Requirements for entering

--- a/node/server.js
+++ b/node/server.js
@@ -5150,12 +5150,10 @@ function init_io() {
 
 					const instanceExists = data.name && instances[data.name] && instances[data.name].map == data.place;
 
-					if (data.name) {
-						// Player requested to enter an existing instance
-						if (!instances[data.name]) {
-							// The instance doesn't exist
-							return fail_response("transport_cant_invalid");
-						}
+					// Player requested to enter an existing instance
+					if (!instanceExists) {
+						// The instance doesn't exist
+						return fail_response("transport_cant_invalid");
 					}
 
 					// Requirements for entering

--- a/node/server.js
+++ b/node/server.js
@@ -5038,35 +5038,6 @@ function init_io() {
 				} else {
 					return fail_response("cant_enter");
 				}
-			} else if (data.place == "winter_instance") {
-				var f = "cave";
-				var ref = G.maps.cave.spawns[2];
-				var item = "cryptkey";
-				if (data.place == "winter_instance") {
-					f = "winterland";
-					ref = G.maps.winterland.spawns[5];
-					item = "frozenkey";
-				}
-				if (simple_distance(player, { in: f, map: f, x: ref[0], y: ref[1] }) > 120) {
-					return fail_response("transport_cant_reach");
-				}
-				if (data.name) {
-					// Player requested to enter an existing instance
-					if (instances[data.name] && instances[data.name].map == data.place) {
-						// The instance exists
-						transport_player_to(player, data.name);
-					} else {
-						// The instance doesn't exist
-						return fail_response("transport_cant_invalid");
-					}
-				} else {
-					if (!consume_one_by_id(player, item)) {
-						return fail_response("transport_cant_item");
-					}
-					instance = create_instance(name, data.place);
-					transport_player_to(player, name);
-				}
-				resend(player, "u+cid+reopen");
 			} else if (data.place == "dungeon0" && player.role == "gm") {
 				instance = create_instance(name, "dungeon0", { solo: player.id });
 				transport_player_to(player, name);

--- a/node/server.js
+++ b/node/server.js
@@ -5025,7 +5025,7 @@ function init_io() {
 			// 	if(data.place!="resort" && !G.maps[player.map].ref.transporter || simple_distance(G.maps[player.map].ref.transporter,player)>80) return socket.emit("game_response","transport_cant_reach");
 			// 	if(data.place=="resort" && player.map!="resort") return socket.emit("game_response","transport_cant_reach");
 			// }
-			server_log(data);
+			server_log(`${player.name} enter ${JSON.stringify(data)}`);
 			var name = randomStr(24);
 			if (data.place == "resort" && 0) {
 				var name = "resort_" + data.name;
@@ -5166,20 +5166,22 @@ function init_io() {
 						let inRange = !validateRange;
 
 						if (validateRange) {
-							server_log(`${gMap.enter.locations.length} locations to validate`);
+							server_log(`${data.place} ${player.name} ${gMap.enter.locations.length} locations to validate`);
 							for (const [locationsMapKey, locationType, locationIndex, range = 120] of gMap.enter.locations) {
 								if (!G.maps[locationsMapKey]) {
-									server_log(`G.maps.${locationsMapKey} does not exist`);
+									server_log(`${data.place} ${player.name} G.maps.${locationsMapKey} does not exist`);
 									continue;
 								}
 
 								if (!G.maps[locationsMapKey][locationType]) {
-									server_log(`G.maps.${locationsMapKey}.${locationType} does not exist`);
+									server_log(`${data.place} ${player.name} G.maps.${locationsMapKey}.${locationType} does not exist`);
 									continue;
 								}
 
 								if (!G.maps[locationsMapKey][locationType][locationIndex]) {
-									server_log(`G.maps.${locationsMapKey}.${locationType}.${locationIndex} does not exist`);
+									server_log(
+										`${data.place} ${player.name} G.maps.${locationsMapKey}.${locationType}.${locationIndex} does not exist`,
+									);
 									continue;
 								}
 
@@ -5192,7 +5194,7 @@ function init_io() {
 								});
 
 								server_log(
-									`G.maps.${locationsMapKey}.${locationType}.${locationIndex} ${distanceToLocation} <= ${range}`,
+									`${data.place} ${player.name} G.maps.${locationsMapKey}.${locationType}.${locationIndex} ${distanceToLocation} <= ${range}`,
 								);
 
 								if (distanceToLocation <= range) {
@@ -5215,20 +5217,13 @@ function init_io() {
 							for (let i = 0; i < player.items.length; i++) {
 								const item = player.items[i];
 								if (item && quantityByItem[item.name]) {
-									server_log(`${data.place} player has ${item.q} x ${item.name} in slot ${i}`);
-									const gItem = G.items[item.name];
-									if (gItem.s) {
-										const quantity = Math.min(item.q, quantityByItem[item.name]);
+									server_log(`${data.place} ${player.name} has ${item.q || 1} x ${item.name} in slot ${i}`);
 
-										quantityByItem[item.name] -= quantity;
-										server_log(`${data.place} ${data.name} ${quantity} x ${item.name} to be removed`);
-										itemsToConsume.push([i, quantity]);
-									} else {
-										// TODO: handle non stackable items
-										server_log(
-											`${data.place} player has ${item.name} in slot ${i} that is not stackable, how to handle?`,
-										);
-									}
+									const quantity = Math.min(item.q || 1, quantityByItem[item.name]);
+
+									quantityByItem[item.name] -= quantity;
+									server_log(`${data.place} ${player.name} ${quantity} x ${item.name} to be removed`);
+									itemsToConsume.push([i, quantity]);
 
 									if (quantityByItem[item.name] == 0) {
 										delete quantityByItem[item.name];
@@ -5243,7 +5238,6 @@ function init_io() {
 							}
 
 							for (const [inventory_index, quantity] of itemsToConsume) {
-								// TODO: will throw an error if quantity is spread over multiple stacks
 								consume(player, inventory_index, quantity);
 							}
 						}
@@ -5251,12 +5245,12 @@ function init_io() {
 
 					if (instanceExists) {
 						// transport to an existing instance
-						server_log(`entering existing instance ${data.place} ${data.name}`);
+						server_log(`${player.name} entering existing instance ${data.place} ${data.name}`);
 						// TODO: transport player to the spawn point the door maps too
 						transport_player_to(player, data.name);
 					} else {
 						// name is a random generated instance id
-						server_log(`entering new instance ${data.place} ${name}`);
+						server_log(`${player.name} entering new instance ${data.place} ${name}`);
 						instance = create_instance(name, data.place);
 						// TODO: transport player to the spawn point the door maps too
 						transport_player_to(player, name);

--- a/node/server.js
+++ b/node/server.js
@@ -5179,6 +5179,14 @@ function init_io() {
 
 					const instanceExists = data.name && instances[data.name] && instances[data.name].map == data.place;
 
+					if (data.name) {
+						// Player requested to enter an existing instance
+						if (!instances[data.name]) {
+							// The instance doesn't exist
+							return fail_response("transport_cant_invalid");
+						}
+					}
+
 					// Requirements for entering
 					if (gMap.enter) {
 						// Is there a place you need to be near to use the key

--- a/node/server.js
+++ b/node/server.js
@@ -5210,10 +5210,7 @@ function init_io() {
 						if (gMap.enter.items && !instanceExists) {
 							const itemsToConsume = [];
 
-							const quantityByItem = {};
-							for (const [itemKey, quantity] of gMap.enter.items) {
-								quantityByItem[itemKey] = quantity;
-							}
+							const quantityByItem = gMap.enter.items;
 
 							for (let i = 0; i < player.items.length; i++) {
 								const item = player.items[i];

--- a/node/server.js
+++ b/node/server.js
@@ -5038,7 +5038,7 @@ function init_io() {
 				} else {
 					return fail_response("cant_enter");
 				}
-			} else if (data.place == "crypt" || data.place == "winter_instance") {
+			} else if (data.place == "winter_instance") {
 				var f = "cave";
 				var ref = G.maps.cave.spawns[2];
 				var item = "cryptkey";


### PR DESCRIPTION
Currently `crypt` and `winter_instance` is hardcoded in the `socket.on("enter")` event, this change allows us to configure it instead of having to hardcode each new instance.  I have verified that the correct key is still required and you still need to be near the correct door

This is also something that is used in the bee dungeon I'm working on. Figured it would make sense with a smaller PR only containing this change. 

 A future extension could be `class` or `level` requirements to enable class specific instances or min/max levels.

# Engine Enhancements
- You can now configure `.enter` requirements in maps.py
  - You can configure items and locations
  - `.enter.items` is an object the item required as the key and the amount required as the values, multiple items and their quantity required can be specified
  ```python
  enter: {
      items: {
          #requires 1 beekey to enter
          "beekey": 1
      }
  }
  ```
  - `enter.locations` is an array of tuples with a list of locations where you have to be near one of them to enter, this could also allow you to enter the instance from different doors leading to different spawn points.
  ``` python
  "locations": [
 	#[mapKey, locationType, locationIndex, range]
 	["main", "spawns", 19, 120], # log near mansion
 	["main", "quirks", 10, 120], # log near mansion
 	["main", "doors", 13, 120] # log near mansion
  ]
  ```
