### PR TITLE
Specific messages instead of FFT for disengage

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2400,8 +2400,42 @@ function init_socket(args)
 			}
 			else if(data.type=="disengage")
 			{
-				var m=get_entity(data.id);
-				if(m) d_text("FFT..",m,{color:"#84A1D1"});
+				// disengage |  event_lop can cause monsters to randomly disengage, this is during the grinch event.
+				// cant_move_smart |  if smart move fails to move the monster to the target
+				// kill_monster |  call relates to free_last_hits
+				// firecrackers | 
+				// stop() | mechagnomes
+				// defeat | defeated_by_a_monster function
+				// redirect | something with the rage_list
+				// anger
+				// warpstomp
+				// exceeds_range
+				// cant_move
+				let text = "FFT..";
+				let color = "#84A1D1";
+				switch (data.cause) {
+					case "taunt redirect":
+						text = "GRR.."
+						break;
+					case "agitate redirect":
+						text = "GRRRR.."
+						break;
+					case "absorb redirect":
+						text = "GRRR.."
+						break;
+					case "bored":
+						// if last attack is too long ago.
+						text = "Yawns.."
+					case "player_gone":
+						// different instance, dead player, invis player
+						text = "Huh?!"
+					case "scare":
+						text = "EEP.."
+						break;
+				}
+
+				const m = get_entity(data.id);
+				if(m) d_text(text, m, {color});
 			}
 			else if(data.type=="mheal")
 			{

--- a/js/game.js
+++ b/js/game.js
@@ -2400,6 +2400,11 @@ function init_socket(args)
 			}
 			else if(data.type=="disengage")
 			{
+				const m = get_entity(data.id);
+				if(!m) {
+					return
+				}
+				
 				// disengage |  event_lop can cause monsters to randomly disengage, this is during the grinch event.
 				// cant_move_smart |  if smart move fails to move the monster to the target
 				// kill_monster |  call relates to free_last_hits
@@ -2434,8 +2439,7 @@ function init_socket(args)
 						break;
 				}
 
-				const m = get_entity(data.id);
-				if(m) d_text(text, m, {color});
+				d_text(text, m, {color});
 			}
 			else if(data.type=="mheal")
 			{

--- a/node/server.js
+++ b/node/server.js
@@ -11430,7 +11430,8 @@ function stop_pursuit(monster, args) {
 	monster.u = true;
 	monster.irregular = 2;
 	calculate_monster_stats(monster);
-	xy_emit(monster, "ui", { id: monster.id, type: "disengage", event: true });
+	// Forward args.cause to the UI so it can give different messages
+	xy_emit(monster, "ui", { id: monster.id, type: "disengage", event: true, cause: args.cause });
 }
 
 function defeated_by_a_monster(attacker, player) {
@@ -11752,7 +11753,7 @@ function update_instance(instance) {
 					var theone = random_one(c);
 					if (theone) {
 						if (monster.target && get_player(monster.target)) {
-							stop_pursuit(monster);
+							stop_pursuit(monster, { cause: "anger" });
 						}
 						target_player(monster, theone);
 					}
@@ -11777,7 +11778,7 @@ function update_instance(instance) {
 						var theone = random_one(c);
 						if (theone) {
 							if (monster.target && get_player(monster.target)) {
-								stop_pursuit(monster);
+								stop_pursuit(monster, { cause: "warpstomp" });
 							}
 							target_player(monster, theone);
 							port_monster(monster, theone, { stomp: 160 });


### PR DESCRIPTION
This PR gives some more visual feedback as to why a mob disengages it's target instead of only writing `FFT..`
It was also a change I made in regards to the bee dungeon, so I've extracted it out into a smaller PR

The following reasons displays a different text
- `Taunt` goes `GRR..`
- `Agitate` goes `GRRRR..`
- `Absorb Sins` goes `GRRR..`
- A mob being bored due to attacks taking to long goes `Yawns..`
- Player disappearing due to map, instance, dead, invis goes `Huh?!` 
- Using jacko / `scared` goes `EEP..`

All other reasons still goes `FFT..`