### PR TITLE
init_game now runs server_bfs for instance maps with npcs or monsters

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -378,11 +378,20 @@ function init_game() {
 					create_instance("d_b1");
 					create_instance("d_a1");
 					create_instance("d_a2");
-					server_bfs("crypt");
-					server_bfs("winter_instance");
-					server_bfs("tomb");
-					server_bfs("dungeon0");
-					server_bfs("cgallery");
+
+					for (const name in G.maps) {
+						const gMap = G.maps[name];
+						if (gMap.ignore) {
+							continue;
+						}
+
+						const hasNpcs = gMap.npcs && gMap.npcs.length > 0;
+						const hasMonsters = gMap.monsters && gMap.monsters.length > 0;
+						if (gMap.instance && (hasNpcs || hasMonsters)) {
+							// running this is important for instances, so that npcs and monsters can navigate / move
+							server_bfs(name);
+						}
+					}
 				} else if (gameplay == "dungeon") {
 					for (var name in G.maps) {
 						if (G.maps[name].world == "dungeon") {


### PR DESCRIPTION
This PR makes it easier to make new instances. Instead of hardcoding `server_bfs` for instances in `init_game` it will now dynamically acquire them from G.maps. and run `server_bfs` if there are npcs or monsters in the instance.

This change was initially part of the bee dungeon branch i'm working on.

This is the console output from my ptr server with added debug, keep in mind `create_instance` in `server_functions.js` will also call `server_bfs` if precompute has not been run. 

log output from my change where i've added a console log for precomputed. 
```
2024-08-13 20:48:46 tomb is precomputed
2024-08-13 20:48:46 dungeon0 is precomputed
2024-08-13 20:48:46 shellsisland is precomputed
2024-08-13 20:48:48 crypt is precomputed
2024-08-13 20:48:48 winter_instance is precomputed
```