### PR TITLE
map editor import json

### DIFF
--- a/utility/htmls/map_editor.html
+++ b/utility/htmls/map_editor.html
@@ -158,6 +158,7 @@
 			<div class="gamebutton clickable linesbutton mt5" onclick="toggle_lines();">Info: ON</div>
 			<div class="gamebutton clickable alertbutton mbutton largerfont mt5" onclick="toggle_alert_mode();"><div class='px2'></div>±</div>
 			<div class="gamebutton clickable mt5" onclick="show_json(map_data);">JSON</div>
+			<div class="gamebutton clickable mt5" onclick="show_import_map();">IMPORT</div>
 			{% if resort %}
 				<div class="gamebutton clickable mt5" onclick="show_upload_modal();">UPLOAD</div>
 			{% endif %}

--- a/utility/htmls/map_editor.js
+++ b/utility/htmls/map_editor.js
@@ -1015,6 +1015,55 @@ function show_upload_modal()
 	$('#toprightcorner').show();
 }
 
+function show_import_map() {
+	function onImportMapJsonChange(event) {
+		var reader = new FileReader();
+		reader.onload = onReaderLoad;
+		reader.readAsText(event.target.files[0]);
+	}
+
+	function onReaderLoad(event) {
+		$("#import_map_json").val(event.target.result);
+	}
+
+	function import_map() {
+		const text = $("#import_map_json").val();
+		const json = JSON.parse(text);
+		// console.log(json);
+		for (const key in json) {
+			const value = json[key];
+			map_data[key] = value;
+		}
+
+		$("#toprightcorner").hide();
+		$("#toprightcorner").html("");
+
+		redraw_map();
+	}
+
+	var html = "<div style='font-size: 32px;'>";
+	html +=
+		"<div style='margin-bottom: 20px'>The following will replace all data in your currently loaded map, press save to persist it</div>";
+	html += `
+	<input id="import_map_file" type="file" accept=".json" /><br/>
+	<textarea id="import_map_json" rows="10" style="min-height:600px; min-width:600px"/>
+	<button id="import_map_button" style="margin-bottom:20px;">Import</button>
+	<br/>
+	<br/>
+	`;
+	// html+=`<form method="post" enctype="multipart/form-data">
+	// <input type="file" name="json"/>
+	// <input type="hidden" name="iname" value="map" />
+	// <input type="hidden" name="key" value="{{name}}">
+	// <input type="submit" name="submit" value="Import"/>
+	// </form>`;
+	html += "</div>";
+	$("#toprightcorner").html(html);
+	$("#toprightcorner").show();
+	$("#import_map_file").on("change", onImportMapJsonChange);
+	$("#import_map_button").on("click", import_map);
+}
+
 function rescale_map(nscale)
 {
 	var ox=(map.x-round(width/2))/scale,oy=(map.y-round(height/2))/scale;

--- a/utility/htmls/map_editor.js
+++ b/utility/htmls/map_editor.js
@@ -1118,16 +1118,18 @@ function redraw_map()
 
 	to_delete=[]; deleted=false;
 
-	for(var i=0;i<map_data.placements.length;i++)
-	{
-		var tile=map_data.placements[i];
-		try{
-			if(!is_nun(tile[3])) place_area(tile[0],tile[1],tile[2],tile[3],tile[4],"yes");
-			else place_tile(tile[0],tile[1],tile[2],"yes");
-		}catch(e)
+	if (map_data.placements) {
+		for(var i=0;i<map_data.placements.length;i++)
 		{
-			console.log("Faulty tile detected + deleted"); deleted=true;
-			to_delete.push(i);
+			var tile=map_data.placements[i];
+			try{
+				if(!is_nun(tile[3])) place_area(tile[0],tile[1],tile[2],tile[3],tile[4],"yes");
+				else place_tile(tile[0],tile[1],tile[2],"yes");
+			}catch(e)
+			{
+				console.log("Faulty tile detected + deleted"); deleted=true;
+				to_delete.push(i);
+			}
 		}
 	}
 	


### PR DESCRIPTION
Working on the bee dungeon, I've added an import button to the map editor so it can import the data from JSON. so starting on a fresh map I can import it either by choosing a file or pasting the JSON. It's very crude and could be made prettier, but it works.

Pressing the import button shows this modal
![image](https://github.com/kaansoral/adventureland/assets/9084377/aae1e10e-dba7-4fcf-85f4-b4d12d58e60b)

When you load the json the map will be replaced. Remember to press save to persist it in the database
![image](https://github.com/kaansoral/adventureland/assets/9084377/e73fac70-ddb7-473f-a1b5-c350cf92defe)
Early on in my develop environment I lost my database every time I made code changes, so this works nicely, it also allows to supply a map in a json file for easy import when the server boots up.

It does this by looking in `design/maps/[keyname].json` for a json file with the contents you get from pressing the JSON button in the map editor. This allows for us to easily make a PR containing a map that will be loaded when the server restarts.

This PR is temporarily marked as draft untill Drippy has verified it works on their local environment.