### PR TITLE
Change firecrackers to require friendly players

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -7862,7 +7862,11 @@ function init_io() {
 					);
 					for (var id in instances[player.in].monsters) {
 						var monster = instances[player.in].monsters[id];
-						if (monster.target && distance({ map: player.map, in: player.in, x: x, y: y }, monster) < 64) {
+						if (
+							monster.target &&
+							is_same(player, get_player(monster.target), 1) &&
+							distance({ map: player.map, in: player.in, x: x, y: y }, monster) < 64
+						) {
 							stop_pursuit(monster, { force: true, cause: "firecrackers" });
 						}
 					}


### PR DESCRIPTION
This PR changes firecrackers to require their special behavior to only activate if the mob's target and the player throwing the firecracker are friendly.