### PR TITLE
remove the temp monster drop limitation

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -2025,7 +2025,8 @@ function drop_something(player, monster, share) {
 	 *                       dropped, where item[0] is the drop rate.
 	 * @returns {boolean}  - true if the item should drop,
 	 *                       false if the item should NOT drop.
-	 * [7/17/24] - ATLUS - 'temp' monsters should also roll for drops
+	 * Change Note:
+	 * - [7/17/24] - ATLUS - 'temp' monsters should also roll for drops
 	 */
 	const shouldItemDrop = (item) => {
 		// 1) calculate the drop rate

--- a/node/server.js
+++ b/node/server.js
@@ -2020,11 +2020,13 @@ function drop_something(player, monster, share) {
 	// if(player.level<50 && monster.type=="goo" && mode.low49_200xgoo) monster_mult=200;
 	if (D.drops.monsters[monster.type] && player.tskin != "konami") {
 		D.drops.monsters[monster.type].forEach(function (item) {
-			if (
-				((!monster.temp || item[0] > 0.00001) &&
-					Math.random() / share / player.luckm / monster.level / monster_mult < item[0]) ||
-				mode.drop_all
-			) {
+			// temp monsters should also roll for drops [7/17/24]
+			// 1) calculate drop modifier
+			// 2) use drop modifier on a random roll (0 <= N < 1) for 'actual drop rate'
+			// 3) drop item if the calculated result is under the drop rate's threshold
+			let dropModifier = share / player.luckm / monster.level / monster_mult;
+			let itemShouldDrop = (Math.random() / dropModifier) < item[0];
+			if (itemShouldDrop || mode.drop_all) {
 				// /hp_mult - removed [13/07/18]
 				drop_item_logic(drop, item, is_in_pvp(player, 1));
 			}
@@ -2032,11 +2034,13 @@ function drop_something(player, monster, share) {
 	}
 	if (monster.drops) {
 		monster.drops.forEach(function (item) {
-			if (
-				((!monster.temp || item[0] > 0.00001) &&
-					Math.random() / share / player.luckm / monster.level / monster_mult < item[0]) ||
-				mode.drop_all
-			) {
+			// temp monsters should also roll for drops [7/17/24]
+			// 1) calculate drop modifier
+			// 2) use drop modifier on a random roll (0 <= N < 1) for 'actual drop rate'
+			// 3) drop item if the calculated result is under the drop rate's threshold
+			let dropModifier = share / player.luckm / monster.level / monster_mult;
+			let itemShouldDrop = (Math.random() / dropModifier) < item[0];
+			if (itemShouldDrop || mode.drop_all) {
 				// /hp_mult - removed [13/07/18]
 				drop_item_logic(drop, item, is_in_pvp(player, 1));
 			}

--- a/node/server.js
+++ b/node/server.js
@@ -1939,6 +1939,27 @@ function drop_one_thing(player, items, args) {
 	});
 }
 
+/**
+ * Determines whether an item should drop for a player based
+ * on the drop rate and luck modifiers
+ * @param {Array} item - An array representing the item to be
+ *                       dropped, where item[0] is the drop rate.
+ * @returns {boolean}  - true if the item should drop,
+ *                       false if the item should NOT drop.
+ * [7/17/24] - ATLUS - 'temp' monsters should also roll for drops
+ */
+function shouldItemDrop(item) {
+	// 1) calculate drop modifier
+	// 2) use roll modifier on a random roll (0 <= N < 1)
+	// 3) item drops if the calculated falls below the drop threshold
+
+	let dropRate = item[0];
+	let rollModifier = share / player.luckm / monster.level / monster_mult;
+	let playerRoll = Math.random() / rollModifier < item[0];
+
+	return playerRoll < dropRate;
+}
+
 function drop_something(player, monster, share) {
 	if (monster.pet || monster.trap) {
 		return;
@@ -2017,15 +2038,11 @@ function drop_something(player, monster, share) {
 			}
 		});
 	}
+
 	// if(player.level<50 && monster.type=="goo" && mode.low49_200xgoo) monster_mult=200;
 	if (D.drops.monsters[monster.type] && player.tskin != "konami") {
 		D.drops.monsters[monster.type].forEach(function (item) {
-			// temp monsters should also roll for drops [7/17/24]
-			// 1) calculate drop modifier
-			// 2) use drop modifier on a random roll (0 <= N < 1) for 'actual drop rate'
-			// 3) drop item if the calculated result is under the drop rate's threshold
-			let dropModifier = share / player.luckm / monster.level / monster_mult;
-			let itemShouldDrop = (Math.random() / dropModifier) < item[0];
+			let itemShouldDrop = shouldItemDrop(item);
 			if (itemShouldDrop || mode.drop_all) {
 				// /hp_mult - removed [13/07/18]
 				drop_item_logic(drop, item, is_in_pvp(player, 1));
@@ -2034,12 +2051,7 @@ function drop_something(player, monster, share) {
 	}
 	if (monster.drops) {
 		monster.drops.forEach(function (item) {
-			// temp monsters should also roll for drops [7/17/24]
-			// 1) calculate drop modifier
-			// 2) use drop modifier on a random roll (0 <= N < 1) for 'actual drop rate'
-			// 3) drop item if the calculated result is under the drop rate's threshold
-			let dropModifier = share / player.luckm / monster.level / monster_mult;
-			let itemShouldDrop = (Math.random() / dropModifier) < item[0];
+			let itemShouldDrop = shouldItemDrop(item);
 			if (itemShouldDrop || mode.drop_all) {
 				// /hp_mult - removed [13/07/18]
 				drop_item_logic(drop, item, is_in_pvp(player, 1));

--- a/node/server.js
+++ b/node/server.js
@@ -2035,7 +2035,7 @@ function drop_something(player, monster, share) {
 
 		let dropRate = item[0];
 		let rollModifier = share / player.luckm / monster.level / monster_mult;
-		let playerRoll = Math.random() / rollModifier < item[0];
+		let playerRoll = Math.random() / rollModifier;
 
 		return playerRoll < dropRate;
 	};

--- a/node/server.js
+++ b/node/server.js
@@ -1939,27 +1939,6 @@ function drop_one_thing(player, items, args) {
 	});
 }
 
-/**
- * Determines whether an item should drop for a player based
- * on the drop rate and luck modifiers
- * @param {Array} item - An array representing the item to be
- *                       dropped, where item[0] is the drop rate.
- * @returns {boolean}  - true if the item should drop,
- *                       false if the item should NOT drop.
- * [7/17/24] - ATLUS - 'temp' monsters should also roll for drops
- */
-function shouldItemDrop(item) {
-	// 1) calculate drop modifier
-	// 2) use roll modifier on a random roll (0 <= N < 1)
-	// 3) item drops if the calculated falls below the drop threshold
-
-	let dropRate = item[0];
-	let rollModifier = share / player.luckm / monster.level / monster_mult;
-	let playerRoll = Math.random() / rollModifier < item[0];
-
-	return playerRoll < dropRate;
-}
-
 function drop_something(player, monster, share) {
 	if (monster.pet || monster.trap) {
 		return;
@@ -2038,6 +2017,27 @@ function drop_something(player, monster, share) {
 			}
 		});
 	}
+
+	/**
+	 * Determines whether an item should drop for a player based
+	 * on the drop rate and luck modifiers.
+	 * @param {Array} item - An array representing the item to be
+	 *                       dropped, where item[0] is the drop rate.
+	 * @returns {boolean}  - true if the item should drop,
+	 *                       false if the item should NOT drop.
+	 * [7/17/24] - ATLUS - 'temp' monsters should also roll for drops
+	 */
+	const shouldItemDrop = (item) => {
+		// 1) calculate the drop rate
+		// 2) calculate & use roll modifier on a random roll (0 <= N < 1)
+		// 3) item drops if the calculated falls below the drop rate threshold
+
+		let dropRate = item[0];
+		let rollModifier = share / player.luckm / monster.level / monster_mult;
+		let playerRoll = Math.random() / rollModifier < item[0];
+
+		return playerRoll < dropRate;
+	};
 
 	// if(player.level<50 && monster.type=="goo" && mode.low49_200xgoo) monster_mult=200;
 	if (D.drops.monsters[monster.type] && player.tskin != "konami") {


### PR DESCRIPTION
monsters marked as temp were not rolling for drops if the odds were lesser than 1/100k (1/100,001 or higher).\
speaking with the community, it seems to be an intentionally crafted expression with unintended operational characteristics.\
a short-poll consensus seems the community is aligned that regardless of temp or non-temp, the monster's drops should adhere to its defined loot table.