### PR TITLE
fix early return when checking aggro diffs

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -11517,7 +11517,10 @@ function rage_logic(instance) {
 				player.y <= map_def.rage[3]
 			) {
 				if (Math.random() < player.aggro_diff) {
-					return;
+					// bling vs. cuteness fix [7/17/24]
+					// change return to a continue since this is a
+					// "regular" for loop rather than a .forEach loop
+					continue;
 				}
 				for (var id in instance.monsters) {
 					var monster = instance.monsters[id];


### PR DESCRIPTION
when checking aggro diff, a "regular" for loop iterating over players is nested in a .forEach loop iterating over `map_def`s and a return was used in the regular for loop which stops after the first player.
if the next player would be raged upon, the monster wouldn't rage because of the return.
updating the return to a continue moves to the next player for rage checking.