### PR TITLE
automatic label GitHub action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,6 @@
      commits if your PR already received reviews or comments.
 
      Before submitting a Pull Request, please ensure you've done the following:
-     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
-     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
      - 👷‍♀️ Create small PRs. In most cases this will be possible.
      - ✅ Provide tests for your changes.
      - 📝 Use descriptive commit messages.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+     For Work In Progress Pull Requests, please use the Draft PR feature,
+     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+
+     For a timely review/response, please avoid force-pushing additional
+     commits if your PR already received reviews or comments.
+
+     Before submitting a Pull Request, please ensure you've done the following:
+     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
+     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
+     - 👷‍♀️ Create small PRs. In most cases this will be possible.
+     - ✅ Provide tests for your changes.
+     - 📝 Use descriptive commit messages.
+     - 📗 Update any related documentation and include any relevant screenshots.
+
+     NOTE: If the PR gets "Status: waiting for author" label you can give it back with once done with a `/ready` reply to the PR this will add the "Status: waiting for review" label
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] :sparkles: Feature (Type: feature)
+- [ ] :bug: Bug Fix (Type: bug)
+- [ ] :hammer_and_wrench: Enhancement (Type: enhancement)
+- [ ] :recycle: Refactor
+- [ ] :zap: Optimization (Type: performance)
+- [ ] :memo: Documentation Update (Type: docs)
+- [ ] :boom: Breaking changes
+- [ ] :pencil2: Fix Typos
+- [ ] :lipstick: Scope: UI/UX
+
+## Description
+
+<!--
+Describe the contents of the PR here
+-->
+
+## Related Tickets & Documents
+
+<!--
+For pull requests that relate or close an issue, please include them
+below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+For example having the text: "closes #1234" would connect the current pull
+request to issue 1234.  And when we merge the pull request, Github will
+automatically close the issue.
+-->
+
+- Related Issue #
+- Closes #
+
+## [optional] :camera_flash: Screenshots
+
+If you made UI changes, show us how it looked before the change, and after the change
+
+## [optional] :rocket: Are there any post deployment tasks we need to perform?

--- a/.github/pr-comment.yml
+++ b/.github/pr-comment.yml
@@ -1,0 +1,8 @@
+version: v1
+
+labels:
+  # Give authors the ability to set the Status: waiting for review status by writing /ready in a comment
+  # I've not found a way to remove Status: waiting for author on this event
+  - label: "Status: waiting for review"
+    matcher:
+      comment: "/ready"

--- a/.github/pr-edited.yml
+++ b/.github/pr-edited.yml
@@ -1,0 +1,64 @@
+version: v1
+
+labels:
+  # label Scope:
+  - label: "Scope: meta"
+    sync: true
+    matcher:
+      files: ".github/**"
+  - label: "Scope: central server"
+    # TODO: Where consitutes the central server?
+    sync: true
+    matcher:
+      files: "*.py"
+  - label: "Scope: Game client"
+    sync: true
+    matcher:
+      files: "js/**"
+  - label: "Scope: game server"
+    sync: true
+    matcher:
+      files: "node/**"
+  - label: "Scope: dependencies"
+    sync: true
+    matcher:
+      # packages for js, requirements for python
+      files: ["**/package.json", "**/requirements.txt"]
+  - label: "Scope: Map Editor"
+    sync: true
+    matcher:
+      # utility/htmls/map_editor_info.html,map_editor.html,map_editor.js
+      files: "**/*map_editor*"
+  - label: "Scope: UI/UX"
+    sync: true
+    matcher:
+      # e.g. '- [x] :lipstick:'
+      body: "(\\n|.)*- \\[x\\] :lipstick:(\\n|.)*"
+  # label Type:
+  - label: "Type: bug"
+    sync: true
+    matcher:
+      # e.g. '- [x] :bug:'
+      body: "(\\n|.)*- \\[x\\] :bug:(\\n|.)*"
+      branch: "^bug/.*"
+  - label: "Type: feature"
+    sync: true
+    matcher:
+      # e.g. '- [x] :sparkles:'
+      body: "(\\n|.)*- \\[x\\] :sparkles:(\\n|.)*"
+      branch: "^feature/.*"
+  - label: "Type: enhancement"
+    sync: true
+    matcher:
+      # e.g. '- [x] :hammer_and_wrench:'
+      body: "(\\n|.)*- \\[x\\] :hammer_and_wrench:(\\n|.)*"
+  - label: "Type: docs"
+    sync: true
+    matcher:
+      # e.g. '- [x] :memo:'
+      body: "(\\n|.)*- \\[x\\] :memo:(\\n|.)*"
+  - label: "Type: performance"
+    sync: true
+    matcher:
+      # e.g. '- [x] :zap:'
+      body: "(\\n|.)*- \\[x\\] :zap:(\\n|.)*"

--- a/.github/pr-opened.yml
+++ b/.github/pr-opened.yml
@@ -1,0 +1,68 @@
+version: v1
+
+labels:
+  # Make new PRs get the waiting for review label
+  - label: "Status: waiting for review"
+    matcher:
+      baseBranch: ".*"
+  # label Scope:
+  - label: "Scope: meta"
+    sync: true
+    matcher:
+      files: ".github/**"
+  - label: "Scope: central server"
+    # TODO: Where consitutes the central server?
+    sync: true
+    matcher:
+      files: "*.py"
+  - label: "Scope: Game client"
+    sync: true
+    matcher:
+      files: "js/**"
+  - label: "Scope: game server"
+    sync: true
+    matcher:
+      files: "node/**"
+  - label: "Scope: dependencies"
+    sync: true
+    matcher:
+      # packages for js, requirements for python
+      files: ["**/package.json", "**/requirements.txt"]
+  - label: "Scope: Map Editor"
+    sync: true
+    matcher:
+      # utility/htmls/map_editor_info.html,map_editor.html,map_editor.js
+      files: "**/*map_editor*"
+  - label: "Scope: UI/UX"
+    sync: true
+    matcher:
+      # e.g. '- [x] :lipstick:'
+      body: "(\\n|.)*- \\[x\\] :lipstick:(\\n|.)*"
+  # label Type:
+  - label: "Type: bug"
+    sync: true
+    matcher:
+      # e.g. '- [x] :bug:'
+      body: "(\\n|.)*- \\[x\\] :bug:(\\n|.)*"
+      branch: "^bug/.*"
+  - label: "Type: feature"
+    sync: true
+    matcher:
+      # e.g. '- [x] :sparkles:'
+      body: "(\\n|.)*- \\[x\\] :sparkles:(\\n|.)*"
+      branch: "^feature/.*"
+  - label: "Type: enhancement"
+    sync: true
+    matcher:
+      # e.g. '- [x] :hammer_and_wrench:'
+      body: "(\\n|.)*- \\[x\\] :hammer_and_wrench:(\\n|.)*"
+  - label: "Type: docs"
+    sync: true
+    matcher:
+      # e.g. '- [x] :memo:'
+      body: "(\\n|.)*- \\[x\\] :memo:(\\n|.)*"
+  - label: "Type: performance"
+    sync: true
+    matcher:
+      # e.g. '- [x] :zap:'
+      body: "(\\n|.)*- \\[x\\] :zap:(\\n|.)*"

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,29 @@
+on:
+  issue_comment:
+    # To pickup comment body in pr or issue and generate a label.
+    # Imagine someone comment 'Me too, I get TimeoutException from ...' in comment body.
+    # Generate a 'bug/timeout' label for better triaging!
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment
+    types: [created]
+
+permissions:
+  # Setting up permissions in the workflow to limit the scope of what it can do. Optional!
+  contents: read # the config file
+  issues: write # for labeling issues (on: issues)
+  pull-requests: write # for labeling pull requests (on: pull_request_target or on: pull_request)
+  statuses: write # to generate status
+  checks: write # to generate status
+
+jobs:
+  pr_commented:
+    name: Labeler PR comment
+    # This job only runs for pull request comments
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      # follows semantic versioning. Lock to different version: v1, v1.5, v1.5.0 or use a commit hash.
+      - uses: fuxingloh/multi-labeler@v4 # v4
+        with:
+          # github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
+          config-path: .github/pr-comment.yml # optional, default to '.github/labeler.yml'
+          # config-repo: my-org/my-repo # optional, default to '${{ github.repository }}'

--- a/.github/workflows/pr-edited.yml
+++ b/.github/workflows/pr-edited.yml
@@ -1,0 +1,42 @@
+on:
+  pull_request:
+    # Useful for triaging code review, and generate compliance status check.
+    # Semantic release? Done.
+    # Make a file change in a mono repo. Tag the mono repo getting changed to generate better release!
+    types: [edited]
+
+  pull_request_target:
+    # for OSS with public contributions (forked PR)
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
+    # types: [edited, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [edited]
+
+  # issues:
+  # Useful for triaging error!
+  # '- [x] Is this a bug?' = 'bug' label!
+
+  # issue_comment:
+  #   # To pickup comment body in pr or issue and generate a label.
+  #   # Imagine someone comment 'Me too, I get TimeoutException from ...' in comment body.
+  #   # Generate a 'bug/timeout' label for better triaging!
+  #   types: [created]
+
+permissions:
+  # Setting up permissions in the workflow to limit the scope of what it can do. Optional!
+  contents: read # the config file
+  issues: write # for labeling issues (on: issues)
+  pull-requests: write # for labeling pull requests (on: pull_request_target or on: pull_request)
+  statuses: write # to generate status
+  checks: write # to generate status
+
+jobs:
+  pr_edited:
+    name: Labeler PR Edit
+    runs-on: ubuntu-latest
+    steps:
+      # follows semantic versioning. Lock to different version: v1, v1.5, v1.5.0 or use a commit hash.
+      - uses: fuxingloh/multi-labeler@v4 # v4
+        with:
+          # github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
+          config-path: .github/pr-edited.yml # optional, default to '.github/labeler.yml'
+          # config-repo: my-org/my-repo # optional, default to '${{ github.repository }}'

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,0 +1,31 @@
+on:
+  pull_request:
+    # Useful for triaging code review, and generate compliance status check.
+    # Semantic release? Done.
+    # Make a file change in a mono repo. Tag the mono repo getting changed to generate better release!
+    types: [opened]
+
+  pull_request_target:
+    # for OSS with public contributions (forked PR)
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
+    types: [opened]
+
+permissions:
+  # Setting up permissions in the workflow to limit the scope of what it can do. Optional!
+  contents: read # the config file
+  issues: write # for labeling issues (on: issues)
+  pull-requests: write # for labeling pull requests (on: pull_request_target or on: pull_request)
+  statuses: write # to generate status
+  checks: write # to generate status
+
+jobs:
+  pr_opened:
+    name: Labeler PR Opened
+    runs-on: ubuntu-latest
+    steps:
+      # follows semantic versioning. Lock to different version: v1, v1.5, v1.5.0 or use a commit hash.
+      - uses: fuxingloh/multi-labeler@v4 # v4
+        with:
+          # github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'
+          config-path: .github/pr-opened.yml # optional, default to '.github/labeler.yml'
+          # config-repo: my-org/my-repo # optional, default to '${{ github.repository }}'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: If the PR gets "Status: waiting for author" label you can give it back with once done with a `/ready` reply to the PR this will add the "Status: waiting for review" label
-->

## What type of PR is this? (check all applicable)

- [x] :sparkles: Feature (Type: feature)
- [ ] :bug: Bug Fix (Type: bug)
- [x] :hammer_and_wrench: Enhancement (Type: enhancement)
- [ ] :recycle: Refactor
- [ ] :zap: Optimization (Type: performance)
- [ ] :memo: Documentation Update (Type: docs)
- [ ] :boom: Breaking changes
- [ ] :pencil2: Fix Typos
- [ ] :lipstick: Scope: UI/UX

## Description
This PR adds github actions that uses [Multi Labeler](https://github.com/marketplace/actions/multi-labeler) to give PRs labels automaticly based on files edit in the PR as well as type checkmarks in the body of the PR

- Newly created PR's will get `Status: waiting for review` applied
- Assigns `Scope: XXX` labels depending on edited code paths
- PR author can type /ready to set the `Status: waiting for review` label again
  - I've not found a way to remove `Status: waiting for author` when this comment happens.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## [optional] :camera_flash: Screenshots

If you made UI changes, show us how it looked before the change, and after the change

## [optional] :rocket: Are there any post deployment tasks we need to perform?
