### PR TITLE
Item Changes

### DIFF
--- a/design/drops.py
+++ b/design/drops.py
@@ -506,19 +506,19 @@ drops={
 	],
 	"statamulet":[
 		[1,"intamulet"],
-		[1.2,"stramulet"],
+		[1,"stramulet"],
 		[1,"dexamulet"],
 	],
 	"statbelt":[
 		[1,"intbelt"],
-		[1.05,"strbelt"],
+		[1,"strbelt"],
 		[1,"dexbelt"],
 	],
 	"statring":[
 		[1,"intring"],
 		[1,"vitring"],
 		[1,"dexring"],
-		[1.2,"strring"],
+		[1,"strring"],
 	],
 	"basicelixir":[
 		[1,"elixirvit0"],

--- a/design/items.py
+++ b/design/items.py
@@ -198,7 +198,7 @@ armor={
 		"set":"fury",
 		"tier":1.5,
 		"type":"helmet",
-		"class":["rogue","warrior"],
+		"class":["rogue","warrior","ranger","paladin"],
 		"skin":"fury",
 		"scroll":True,
 		#"evasion":1,
@@ -2031,7 +2031,7 @@ accessories={
 		"skin":"mearring",
 		"luck":8,
 		"compound":{
-			"luck":1,
+			"luck":4,
 		},
 		"name":"Mistletoe Earring",
 		"g":12000000,
@@ -2226,7 +2226,7 @@ accessories={
 		"skin":"stramulet",
 		"str":4,
 		"compound":{
-			"str":2,
+			"str":3,
 		},
 		"name":"Amulet of Strength",
 		"g":30000,
@@ -2244,7 +2244,7 @@ accessories={
 	"t2stramulet":{
 		"type":"amulet",
 		"skin":"t2stramulet",
-		"str":5,
+		"str":6,
 		"resistance":30,
 		"compound":{
 			"str":3,
@@ -2258,10 +2258,10 @@ accessories={
 	"t2intamulet":{
 		"type":"amulet",
 		"skin":"t2intamulet",
-		"int":5,
+		"int":6,
 		"armor":30,
 		"compound":{
-			"int":2,
+			"int":3,
 			"armor":20,
 		},
 		"name":"Amulet of the Fierce Mage",


### PR DESCRIPTION
Balanced Accessory Drop Rates: All belts, rings, and amulets for INT, DEX, and STR now have equal drop rates. STR no longer has better odds.

Stat Amulet Adjustments:
STR Amulet: Base stat increased from 2 → 3.
T2 STR Amulet: Base stat increased from 5 → 6.
T2 INT Amulet: Base stat increased from 5 → 6, scaling per level increased from 2 → 3.

Band of Fury Restriction: Now also restricted to Ranger and Paladin (previously only Warrior and Rogue).

Mistletoe Earring: Luck scaling increased from 1 → 4