### PR TITLE
Fix Sanguine Amulet

### DIFF
--- a/design/conditions.py
+++ b/design/conditions.py
@@ -377,7 +377,6 @@ conditions={
 	},
 	"sanguine":{
 		"skin":"sanguine",
-		"lifesteal":1,
 		"name":"Vampiric Aura",
 		"attr0":"lifesteal",
 		"buff":True,

--- a/design/items.py
+++ b/design/items.py
@@ -2217,7 +2217,7 @@ accessories={
 		"dex":5,
 		"int":5,
 		"str":5,
-		"attr0":1,
+		"attr0":2,
 		"hp":1200,
 		"aura":"sanguine",
 		"compound":{


### PR DESCRIPTION
The Sanguine Amulet has long bugged me that it says that it gives 1% lifesteal, but it actually gives 2%. This PR fixes this issue by making the Sanguine Amulet actually say that it gives that 2% lifesteal, and making the Sanguine buff actually respect that amount.