### PR TITLE
New "spawns" mechanic

### DIFF
--- a/js/html.js
+++ b/js/html.js
@@ -540,7 +540,7 @@ function render_monster(monster)
 	if(def.immune) html+=info_line({line:"IMMUNE",color:"#AEAEAE"});
 	if(def.peaceful) html+=info_line({line:"PEACEFUL",color:"#54B25F"});
 	if(def.supporter) html+=info_line({line:"SUPPORTER",color:"#CA5931"});
-	if(def.spawns) html+=info_line({line:"SPAWNS",color:"#AEAEAE"});
+	//if (def.spawns) html += info_line({ line: "SPAWNS", color: "#AEAEAE" });  this is  just adding an extra line to the mob UI
 	if(def.abilities)
 	{
 		for(var id in def.abilities)
@@ -550,9 +550,6 @@ function render_monster(monster)
 		}
 	}
 	if (def.spawns) {
-		// Header
-		html += info_line({ line: "SPAWNS", color: "#AEAEAE" });
-
 		// Collect info
 		const spawnInfo = {};
 

--- a/node/server.js
+++ b/node/server.js
@@ -11967,35 +11967,67 @@ function update_instance(instance) {
 				set_ghash(aggressives, monster, 32);
 			}
 		}
-		if (monster.target && monster.spawns && get_player(monster.target) && !is_disabled(monster)) {
-			monster.spawns.forEach(function (spi) {
-				var interval = spi[0];
-				var name = spi[1];
-				if (!monster.last[name] || mssince(monster.last[name]) > interval) {
-					var pname = random_one(Object.keys(monster.points));
-					var player = get_player(pname);
-					if (!player || player.npc || distance(monster, player) > 400) {
-						return;
-					}
-					if (!is_same(player, get_player(monster.target), true)) {
-						return;
-					}
-					monster.last[name] = new Date();
-					var spot = safe_xy_nearby(player.map, player.x + Math.random() * 20 - 10, player.y + Math.random() * 20 - 10);
-					if (!spot) {
-						return;
-					}
-					new_monster(instance.name, {
-						type: name,
-						stype: "spawn",
-						x: spot.x,
-						y: spot.y,
-						target: player.name,
-						master: monster.id,
-					});
-				}
-			});
-		}
+        if (monster.target && monster.spawns && get_player(monster.target) && !is_disabled(monster)) {
+            monster.spawns.forEach((spi) => {
+                const condition = spi[0];      // interval or "hp:0.75"
+                const name = spi[1];           // monster type
+                const count = spi[2] || 1;     // default to 1
+
+                // --- Timed spawns (existing) ---
+                if (typeof condition === "number") {
+                    if (!monster.last[name] || mssince(monster.last[name]) > condition) {
+                        for (let i = 0; i < count; i++) {
+                            const pname = random_one(Object.keys(monster.points));
+                            const player = get_player(pname);
+                            if (!player || player.npc || distance(monster, player) > 400) return;
+                            if (!is_same(player, get_player(monster.target), true)) return;
+
+                            monster.last[name] = new Date();
+                            const spot = safe_xy_nearby(player.map, player.x + Math.random() * 20 - 10, player.y + Math.random() * 20 - 10);
+                            if (!spot) return;
+
+                            new_monster(instance.name, {
+                                type: name,
+                                stype: "spawn",
+                                x: spot.x,
+                                y: spot.y,
+                                target: player.name,
+                                master: monster.id,
+                            });
+                        }
+                    }
+                }
+
+                // --- HP threshold spawns (new) ---
+                if (typeof condition === "string" && condition.startsWith("hp:")) {
+                    const threshold = parseFloat(condition.split(":")[1]); // e.g. 0.75
+                    const currentHpRatio = monster.hp / monster.max_hp;
+                    const key = name + "_hp_" + threshold;
+
+                    if (currentHpRatio <= threshold && !monster.last[key]) {  // trigger once per fight
+                        for (let i = 0; i < count; i++) {
+                            const pname = random_one(Object.keys(monster.points));
+                            const player = get_player(pname);
+                            if (!player || player.npc || distance(monster, player) > 400) return;
+                            if (!is_same(player, get_player(monster.target), true)) return;
+
+                            const spot = safe_xy_nearby(player.map, player.x + Math.random() * 20 - 10, player.y + Math.random() * 20 - 10);
+                            if (!spot) return;
+
+                            new_monster(instance.name, {
+                                type: name,
+                                stype: "spawn",
+                                x: spot.x,
+                                y: spot.y,
+                                target: player.name,
+                                master: monster.id,
+                            });
+                        }
+                        monster.last[key] = true; // mark this threshold as triggered
+                    }
+                }
+            });
+        }
 		function attack_target_or_move() {
 			var player = players[name_to_id[monster.target]];
 			if (player && ssince(monster.last.attacked) > 20 && Math.random() > monster.rage * 0.99) {


### PR DESCRIPTION
Enhances the existing .spawns mechanic to allow more flexible spawn conditions and quantities, while keeping the original timer-based functionality intact. Also updates the monster UI to display spawns more clearly.

Existing timer-based spawns remain unchanged:
"spawns":[[200,"nerfedmummy"]]
This continues to spawn 1 monster every 200ms as before.

New HP-based spawn option:
Monsters can now spawn additional creatures when their HP reaches a certain threshold:
"spawns":[["hp:0.50", "nerfedmummy", 5]]
This spawns 5 nerfedmummy when the monster hits 50% HP.

Quantity support:
You can now define how many monsters to spawn at a time for both timer-based and HP-based conditions

UI updates:
The "SPAWNS" section in the monster tooltip has been updated to properly display multiple spawns, including HP thresholds and quantities:
<img width="295" height="216" alt="image" src="https://github.com/user-attachments/assets/f4e1f870-0469-46a2-83a2-25140a4fd8be" />
<img width="325" height="258" alt="image" src="https://github.com/user-attachments/assets/74b74b2b-9e8f-4e50-ab87-6fce2236ee28" />

