### PR TITLE
Allow a quantity of items to drop from chests

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -1902,7 +1902,7 @@ function drop_item_logic(drop, def, pvp) {
 	} else if (def[1] == "open") {
 		chest_exchange(drop, def[2]);
 	} else {
-		var item = create_new_item(def[1]);
+		var item = create_new_item(def[1], def[2]);
 		if (pvp) {
 			item.v = new Date();
 		}

--- a/node/server.js
+++ b/node/server.js
@@ -1908,7 +1908,7 @@ function drop_item_logic(drop, def, pvp) {
 		}
 		for (var i = 0; i < drop.items.length; i++) {
 			if (can_stack(drop.items[i], item)) {
-				drop.items[i].q += 1;
+				drop.items[i].q += def[2] ?? 1;
 				added = true;
 				break;
 			}

--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -3540,32 +3540,32 @@ function exchange(player, name, args) {
 }
 
 function chest_exchange(chest, name) {
-	var done = false;
-	var total = 0;
-	var current = 0;
-	D.drops[name].forEach(function (drop) {
-		total += drop[0];
-	});
-	result = Math.random() * total;
-	D.drops[name].forEach(function (drop) {
-		if (done) {
-			return;
-		}
-		current += drop[0];
-		if (result <= current) {
-			done = true;
-			if (drop[1] == "gold") {
-				chest.gold += drop[2];
-			} else if (drop[1] == "shells") {
-				chest.cash += drop[2];
-			} else if (drop[1] == "empty") {
-			} else if (drop[1] == "open") {
-				chest_exchange(chest, drop[2]);
-			} else {
-				chest.items.push(create_new_item(drop[1]));
-			}
-		}
-	});
+    var done = false;
+    var total = 0;
+    var current = 0;
+    D.drops[name].forEach(function (drop) {
+        total += drop[0];
+    });
+    result = Math.random() * total;
+    D.drops[name].forEach(function (drop) {
+        if (done) {
+            return;
+        }
+        current += drop[0];
+        if (result <= current) {
+            done = true;
+            if (drop[1] == "gold") {
+                chest.gold += drop[2];
+            } else if (drop[1] == "shells") {
+                chest.cash += drop[2];
+            } else if (drop[1] == "empty") {
+            } else if (drop[1] == "open") {
+                chest_exchange(chest, drop[2]);
+            } else {
+                chest.items.push(create_new_item(drop[1], drop[2]));
+            }
+        }
+    });
 }
 
 var item_p_ignore = {

--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -3540,32 +3540,32 @@ function exchange(player, name, args) {
 }
 
 function chest_exchange(chest, name) {
-    var done = false;
-    var total = 0;
-    var current = 0;
-    D.drops[name].forEach(function (drop) {
-        total += drop[0];
-    });
-    result = Math.random() * total;
-    D.drops[name].forEach(function (drop) {
-        if (done) {
-            return;
-        }
-        current += drop[0];
-        if (result <= current) {
-            done = true;
-            if (drop[1] == "gold") {
-                chest.gold += drop[2];
-            } else if (drop[1] == "shells") {
-                chest.cash += drop[2];
-            } else if (drop[1] == "empty") {
-            } else if (drop[1] == "open") {
-                chest_exchange(chest, drop[2]);
-            } else {
-                chest.items.push(create_new_item(drop[1], drop[2]));
-            }
-        }
-    });
+	var done = false;
+	var total = 0;
+	var current = 0;
+	D.drops[name].forEach(function (drop) {
+		total += drop[0];
+	});
+	result = Math.random() * total;
+	D.drops[name].forEach(function (drop) {
+		if (done) {
+			return;
+		}
+		current += drop[0];
+		if (result <= current) {
+			done = true;
+			if (drop[1] == "gold") {
+				chest.gold += drop[2];
+			} else if (drop[1] == "shells") {
+				chest.cash += drop[2];
+			} else if (drop[1] == "empty") {
+			} else if (drop[1] == "open") {
+				chest_exchange(chest, drop[2]);
+			} else {
+				chest.items.push(create_new_item(drop[1], drop[2]));
+			}
+		}
+	});
 }
 
 var item_p_ignore = {


### PR DESCRIPTION
Changes the chest drop system to allow multiple copies of the same item in a single entry, removing the need to repeat items in the drop table.

Previous method (still works):
[100,"candy1"], [100,"candy1"]

New quantity field:
[100, "candy1", 2]
Drops 2 candy1 in a single entry.

The new format simplifies drop tables and reduces repetition.