### PR TITLE
Halloween boss incentives

### DIFF
--- a/design/drops.py
+++ b/design/drops.py
@@ -297,8 +297,8 @@ drops={
 			[1.0/1000,"orbofint"],
 			[1.0/1000,"orbofvit"],
 		],
-		"mrpumpkin":[[100,"candy0"],[100,"candy1"],[100,"candy1"],[10,"phelmet"],[10.0/100000,"cxjar",1,"gcandle"],[10.0/100000,"cxjar",1,"breyes"],],
-		"mrgreen":[[100,"candy0"],[100,"candy1"],[100,"candy1"],[10,"gphelmet"],[15.0/100000,"cxjar",1,"bathat"],[1.0/100,"hdagger"]],
+		"mrpumpkin":[[100,"candy0",5],[100,"candy1",10],[100,"candy1"],[10,"phelmet"],[10.0/100000,"cxjar",1,"gcandle"],[10.0/100000,"cxjar",1,"breyes"],],
+		"mrgreen":[[100,"candy0",5],[100,"candy1",10],[100,"candy1"],[10,"gphelmet"],[15.0/100000,"cxjar",1,"bathat"],[1.0/100,"hdagger"]],
 		"jr":[
 			#[1,"swirlipop"],
 			[0.1,"candy0"],[0.1,"candy1"], #[1,"candy1v2"],[1,"candy1v2"],[1,"candy1v2"],[1,"candy1v2"],
@@ -575,6 +575,26 @@ drops={
 			[1.0/1.0,"spidersilk"],
 			[1.0/1.0,"poison"],
 			[1.0/3.0,"troll"],
+		],
+	},
+	"monsters_home_server":{
+		"mrgreen": [
+			[0.001, "fallen"],
+			[1.0,"candy0", 7],
+			[1.0,"candy1", 14],
+			[0.342857, "candy0", 6],
+			[0.342857, "candy1", 12],
+			#[0.045714,"candy0", 15]
+			#[0.085714, "candy1", 55] "jackpot" chance?
+		],
+		"mrpumpkin": [
+			[0.001, "fallen"],
+			[1.0,"candy0", 6],
+			[1.0,"candy1", 12],
+			[0.285714,"candy0", 4],
+			[0.285714,"candy1", 8],
+			#[0.045714,"candy", 15]
+			#[0.045714,"candy1", 45] "jackpot" chance?
 		],
 	},
 	"konami":[

--- a/design/monsters.py
+++ b/design/monsters.py
@@ -754,6 +754,8 @@ monsters={
 		"respawn":94*60,
 		"gold":16000,"range":620,"frequency":1.6,"aggro":1,"rage":1,"apiercing":320,"resistance":900,"cooperative":True,"announce":"#256943",
 		"cbuff":[[60,"halloween0"],[70,"halloween1"],[200,"halloween2"]],
+		"spawns":[["hp:0.75", "greenjr", 5],["hp:0.50", "greenjr", 5],["hp:0.25", "greenjr", 5]],
+		# "spawns":[[threshold, monster type, count]]
 		"slots":{"mainhand":{"name":"gbow","level":10}},
 		"achievements":[
 			[1,"stat","hp",10],
@@ -786,6 +788,8 @@ monsters={
 		"phresistance":30,
 		"gold":16000,"range":520,"frequency":1,"aggro":0.05,"hit":"explode_c","cooperative":True,"announce":"#FD8940",
 		"cbuff":[[60,"halloween0"],[70,"halloween1"],[200,"halloween2"]],
+		"spawns":[["hp:0.75", "jr", 5],["hp:0.50", "jr", 5],["hp:0.25", "jr", 5]],
+		# "spawns":[[threshold, monster type, count]]
 		"slots":{"mainhand":{"name":"oozingterror","level":8}},
 		"achievements":[
 			[1,"stat","hp",10],
@@ -802,7 +806,7 @@ monsters={
 		"cbuff":[[60,"halloween0"],[70,"halloween1"],[200,"halloween2"]],
 		"respawn":480 and 12*72*60, #sprocess_game_data
 		"gold":16000,"range":80,"frequency":20,"aggro":1,"rage":1,"rpiercing":420,"resistance":400,"evasion":40,"reflection":4,
-		"difficulty":2,
+		"difficulty":2,"cooperative":True,
 		"achievements":[
 			[1,"stat","mp",10],
 			[10,"stat","vit",1],
@@ -818,7 +822,7 @@ monsters={
 		"cbuff":[[60,"halloween0"],[70,"halloween1"],[200,"halloween2"]],
 		"respawn":480 and 6*72*60, #sprocess_game_data
 		"gold":6000,"range":30,"frequency":20,"aggro":1,"rage":1,"resistance":400,"evasion":80,
-		"difficulty":2,
+		"difficulty":2,"cooperative":True,
 		"achievements":[
 			[1,"stat","mp",10],
 			[10,"stat","vit",1],


### PR DESCRIPTION
Improves incentives for farming Halloween event bosses by leveraging the new .spawns mechanic and home-server-specific drops.

After community feedback, it was clear that Halloween bosses were largely ignored in favor of farming normal mobs.
This PR specifically enhances boss loot tables and makes the fights more intriguing by using the newly created .spawns mechanic.
Home-server-specific drops give exclusive rewards to players on their home server, making the bosses worth engaging without promoting server hopping.