### PR TITLE
Improve Stompy's Nose Ring STR scaling

### DIFF
--- a/design/items.py
+++ b/design/items.py
@@ -2211,7 +2211,7 @@ accessories={
 		"dex":2,
 		"armor":20,
 		"compound":{
-			"str":2,
+			"str":3,
 			"dex":1,
 			"armor":5,
 		},


### PR DESCRIPTION
After the changes in #165, Stompy's Nose Ring was no longer holding its place as a strict upgrade to the STR Amulet.

Similar to #165, this change will improve Stompy's Nose Ring scaling from 2 per level to 3 per level.