### PR TITLE
Fix miss so that it uses the value from the attack, instead of the attacker

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -3235,7 +3235,7 @@ function complete_attack(attacker, target, info) {
 	} else if (
 		target.dc ||
 		target.dead ||
-		(attacker.miss && Math.random() * 100 < attacker.miss) ||
+		(info.miss && Math.random() * 100 < info.miss) ||
 		(target.avoidance && Math.random() * 100 < target.avoidance)
 	) {
 		return xy_emit(


### PR DESCRIPTION
The value is already being assigned to the info object, so it seems clear that it is intended to be used, but it isn't.