### PR TITLE
Pass the target parameter to consume_mp for more skills

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -9149,7 +9149,7 @@ function init_io() {
 					resolve = c_resolve;
 				}
 			} else if (data.name == "magiport") {
-				consume_mp(player, gSkill.mp);
+				consume_mp(player, gSkill.mp, target);
 				if (!is_pvp && mode.pve_safe_magiports) {
 					if (!magiportations[player.name]) {
 						magiportations[player.name] = {};


### PR DESCRIPTION
This is so that the Restore MP ability property recognizes the target as a humanoid for skills that are targeted.