### PR TITLE
Change damage type of the snowball to Pure, to match the projectile

### DIFF
--- a/design/skills.py
+++ b/design/skills.py
@@ -156,6 +156,7 @@ skills={
 		"projectile":"snowball",
 		"target":True,
 		"merchant_use":True,
+		"damage_type":"pure",
 	},
 	"scare":{
 		"type":"skill",


### PR DESCRIPTION
The projectile has the `.pure = true` flag set, but as far as I can tell, it's the only projectile in the game to have this flag set, and the skill doesn't deal pure damage. Since the skill previously was lacking a damage type, it would default to "physical", which meant the snowball itself was affected by armor piercing and defense.