### PR TITLE
Add `operation` to bank deposit and withdraw

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -7854,13 +7854,13 @@ function init_io() {
 				var amount = max(0, min(parseInt(data.amount) || 0, player.user.gold));
 				player.user.gold -= amount;
 				player.gold += amount;
-				success = { response: "bank_withdraw", gold: amount, cevent: true };
+				success = { operation: "withdraw", gold: amount, cevent: true };
 			}
 			if (data.operation == "deposit") {
 				var amount = max(0, min(parseInt(data.amount) || 0, player.gold));
 				player.user.gold += amount;
 				player.gold -= amount;
-				success = { response: "bank_store", gold: amount, cevent: true };
+				success = { operation: "deposit", gold: amount, cevent: true };
 			}
 			if (data.operation == "unlock") {
 				if (!bank_packs[data.pack]) {


### PR DESCRIPTION
Right now the `response` value is being overwritten in `success_response` to `data`, so they both return the same game response

```json
{"response":"data","gold":1,"cevent":true,"success":true,"place":"bank"}
```