### PR TITLE
Tweak drop table multiplier logic

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -2059,10 +2059,10 @@ function drop_something(player, monster, share) {
 	// if(player.level<50 && monster.type=="goo" && mode.low49_200xgoo) monster_mult=200;
 	if (D.drops.monsters[monster.type] && player.tskin != "konami") {
 		D.drops.monsters[monster.type].forEach(function (item) {
-			let itemShouldDrop = shouldItemDrop(item);
-			if (itemShouldDrop || mode.drop_all) {
-				// /hp_mult - removed [13/07/18]
-				for (var d = 0; d < B.drop_table_multiplier; d++) {
+			for (let d = 0; d < B.drop_table_multiplier; d++) {
+				let itemShouldDrop = shouldItemDrop(item);
+				if (itemShouldDrop || mode.drop_all) {
+					// /hp_mult - removed [13/07/18]
 					drop_item_logic(drop, item, is_pvp);
 				}
 			}


### PR DESCRIPTION
https://github.com/kaansoral/adventureland/blob/1027bbc7d64ee05a14b3e1347bab189319faee25/node/server.js#L114 says "2 means drop tables extended by their original selves, not %'s multiplied",

so I assume, if you had an original 1/5 chance to drop an item, with it extended, you want *another* 1/5 chance to drop an item, not a 1/5 chance to get 2 items.